### PR TITLE
Bug: Changing routes keeps current scroll position

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^0.14.5",
     "react-ga": "^1.2.1",
     "react-router": "^2.0.1",
+    "scroll-behavior": "^0.3.3",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "victory": "latest"

--- a/src/components/entry.jsx
+++ b/src/components/entry.jsx
@@ -1,10 +1,17 @@
 import React from "react";
 import { render } from "react-dom";
-import { Router, browserHistory } from "react-router";
+import { Router, useRouterHistory } from "react-router";
+import createBrowserHistory from "history/lib/createBrowserHistory";
+import useScroll from "scroll-behavior/lib/useStandardScroll";
 // import routes and pass them into <Router/>
 import routes from "../routes";
 
+const appHistory = useScroll(useRouterHistory(createBrowserHistory))();
+
 render(
-  <Router routes={routes} history={browserHistory}/>,
+  <Router
+    history={appHistory}
+    routes={routes}
+  />,
   document.getElementById("content")
 );


### PR DESCRIPTION
Bug fix! When changing routes, the page scrolls back to the top now. 
