### PR TITLE
Update build matrix and deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "4.2"
   - "5.0"
 
 # Use container-based Travis infrastructure.
@@ -22,6 +23,10 @@ before_install:
   # Decrypt the key file
   - openssl aes-256-cbc -K $encrypted_94338e915bdd_key -iv $encrypted_94338e915bdd_iv
     -in deploy_static.pem.enc -out deploy_static.pem -d
+
+  # Install npmv3 because of postinstall bugs in npmv2:
+  # See https://github.com/FormidableLabs/victory/issues/98
+  - npm install -g npm@3
 
 install:
   - npm install

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,28 @@
-#!/bin/sh
+#!/bin/bash
 
+# Capture which build we are. Travis provides in the form of:
+# `GLOBAL_NUMBER.SUBBUILD_NUMBER`. We're going to want the subbuild number
+# so that we can detect the "first" vs. "other" builds.
+#
+# Bash hackery reference for `##*.` thing:
+# http://tecadmin.net/how-to-extract-filename-extension-in-shell-script/#
+BUILD_SUFFIX=${TRAVIS_JOB_NUMBER##*.}
+echo "BUILD_SUFFIX: ${BUILD_SUFFIX}"
+
+# Early exit if we aren't the first build.
+if [[ "${BUILD_SUFFIX}" != "1" ]]; then
+  echo "Build number: ${TRAVIS_JOB_NUMBER}. Skipping deployment."
+  exit 0
+fi
+
+# Otherwise, continue and do the actual deploy.
+echo "Build number: ${TRAVIS_JOB_NUMBER}. Starting deployment."
+
+# make sure key is permissive, but not too permissive
 chmod 600 deploy_static.pem
+# clean out any existing staging folder but make sure it exists
 ssh -i deploy_static.pem formidable@192.241.218.94 "rm -rf static/victory-docs-staging && mkdir static/victory-docs-staging"
+# copy the victory build to the staging arena; if this fails, site is still OK
 scp -i ./deploy_static.pem -rp ./build/* formidable@192.241.218.94:/home/formidable/static/victory-docs-staging
+# rename the staging arena to the actual victory site
 ssh -i ./deploy_static.pem formidable@192.241.218.94 "rm -rf static/victory && mv static/victory-docs-staging/ static/victory"
-echo "DEPLOYED."
-exit 0


### PR DESCRIPTION
- Add node v4.2 to the build matrix
- Add logic to `deploy.sh` to skip deployment on all but the _first_ travis subbuild to ensure a single deployment.
