### PR TITLE
Remove unneeded codemirror references

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@
   <div id="content">
     <p style="text-align: center;">Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <!-- Code Mirror -->
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
   <script async defer type="text/javascript" src="main.js"></script>
 </body>
 </html>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -22,9 +22,6 @@
 </head>
 <body>
   <div id="content">{{{content}}}</div>
-  {{!-- Code Mirror --}}
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
   <script async defer type="text/javascript" src="{{bundleJs}}"></script>
 </body>
 </html>


### PR DESCRIPTION
This will remove the unused external libraries for codemirror, they are bundled with the component-library package.

Fixes https://github.com/FormidableLabs/formidable-landers/issues/106

cc @paulathevalley 
