### PR TITLE
Add user-agent for static rendering. Fixes invalid styles

### DIFF
--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -38,6 +38,11 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
 
 // Exported static site renderer:
 export default (locals, callback) => {
+  // userAgent for radium vendor prefixing
+  global.navigator = {
+    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2454.85 Safari/537.36"
+  };
+
   const history = createMemoryHistory();
   const location = history.createLocation(locals.path);
 


### PR DESCRIPTION
With javascript disabled, we now get:

👍 
![image](https://cloud.githubusercontent.com/assets/848347/17228551/4f8c018c-54c8-11e6-9ab5-08c747814c69.png)

instead of

:-1:
![image](https://cloud.githubusercontent.com/assets/848347/17228563/5a0cb48a-54c8-11e6-9082-5d8e0fe746fd.png)

@kylecesmat @paulathevalley 
