### PR TITLE
Move Theme Park to docs & Refactor

### DIFF
--- a/src/components/config-recipes.js
+++ b/src/components/config-recipes.js
@@ -5,7 +5,7 @@ import CustomStyles from "victory-examples/docs/custom-styles/docs";
 import MultipleAxes from "victory-examples/docs/multiple-axes/docs";
 import Tooltip from "victory-examples/docs/tooltip/docs";
 import CandlestickDashboard from "victory-examples/docs/candlestick-dashboard/docs";
-import ThemePark from "victory-examples/docs/theme-park/docs";
+import ThemePark from "../screens/recipes/components/theme-park";
 
 export const recipesComponents = [
   {

--- a/src/screens/recipes/components/theme-park/default.example.js
+++ b/src/screens/recipes/components/theme-park/default.example.js
@@ -1,0 +1,34 @@
+/* NOTE
+  all one-line star comments starting with "eslint", "global", or "NOTE"
+  will be removed before displaying this document to the user
+*/
+/* global React, ReactDOM, DemoVictoryComponent, mountNode */
+/* eslint-disable no-constant-condition */
+
+/*
+  "default" theme
+  The default theme is just an empty object, {}.
+  Change the if statement below to true and see how the styles change.
+*/
+
+let theme = {};
+
+if (false) { // won't run unless you change this to true!
+  theme = {
+    pie: {
+      props: {},
+      style: {
+        data: {
+          stroke: "black",
+          strokeWidth: 3
+        },
+        labels: {
+          padding: 100,
+          fontFamily: "monospace"
+        }
+      }
+    }
+  };
+}
+
+ReactDOM.render(<DemoVictoryComponent theme={theme}/>, mountNode);

--- a/src/screens/recipes/components/theme-park/index.js
+++ b/src/screens/recipes/components/theme-park/index.js
@@ -1,0 +1,252 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Radium, { Style } from "radium";
+import Playground from "component-playground";
+import { assign, times } from "lodash";
+import {
+  VictoryChart, VictoryScatter, VictoryPie, VictoryLine, VictoryStack, VictoryBar, VictoryAxis
+} from "victory";
+
+import { VictorySettings } from "formidable-landers";
+
+const scatterData = times(20, (i) => ({
+  x: (i - 10) / 3,
+  y: i / 2 - 2 * Math.random() - 4
+}));
+
+const toInteger = (number) => parseInt(number).toString();
+
+class DemoVictoryComponent extends React.Component {
+  render() {
+    const { theme } = this.props;
+    const positions = [
+      {transform: "translate(0, -15)"},
+      {transform: "translate(180, -40)"},
+      {transform: "translate(-10, 140)"},
+      {transform: "translate(180, 140)"}
+    ];
+    return (
+      <svg viewBox="0 0 400 400" role="img" aria-labelledby="title desc"
+        style={{height: "auto", width: "100%"}}
+      >
+        <g transform={positions[0].transform}>
+          <VictoryPie theme={theme} standalone={false} height={200}/>
+        </g>
+
+        <g transform={positions[1].transform}>
+          <VictoryChart theme={theme} standalone={false} height={250} width={250}>
+            <VictoryAxis tickCount={3} tickFormat={toInteger}/>
+            <VictoryAxis tickCount={4} dependentAxis/>
+            <VictoryScatter
+              size={2}
+              data={scatterData}
+            />
+          </VictoryChart>
+        </g>
+
+        <g transform={positions[2].transform}>
+          <VictoryChart theme={theme} standalone={false} height={250} width={200}>
+            <VictoryAxis tickCount={4} domain={[0, 3]} tickFormat={toInteger}/>
+            <VictoryAxis tickCount={4} dependentAxis domain={[0, 10]}/>
+            <VictoryLine
+              y={(data) => data.x * data.x}
+            />
+          </VictoryChart>
+        </g>
+
+        <g transform={positions[3].transform}>
+          <VictoryChart
+            standalone={false}
+            theme={theme}
+            height={250}
+            width={250}
+            domainPadding={{x: 50}}
+          >
+            <VictoryAxis tickValues={["A", "B", "C"]}/>
+            <VictoryAxis tickCount={3} dependentAxis/>
+            <VictoryStack>
+              <VictoryBar
+                data={[
+                  {x: "apples", y: 1},
+                  {x: "bananas", y: 3},
+                  {x: "oranges", y: 3}
+                ]}
+              />
+              <VictoryBar
+                data={[
+                  {x: "apples", y: 2},
+                  {x: "bananas", y: 1},
+                  {x: "oranges", y: 3}
+                ]}
+              />
+              <VictoryBar
+                data={[
+                  {x: "apples", y: 3},
+                  {x: "bananas", y: 1},
+                  {x: "oranges", y: 1}
+                ]}
+              />
+            </VictoryStack>
+          </VictoryChart>
+        </g>
+      </svg>
+    );
+  }
+}
+
+DemoVictoryComponent.propTypes = {
+  theme: React.PropTypes.object
+};
+
+class PureRender extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return Object.keys(nextProps).reduce((changed, key) => {
+      if (changed) {
+        return true; // if any prop has changed, update the component
+      } else {
+        const current = this.props[key];
+        const next = nextProps[key];
+        if (typeof next === "object") {
+          return false; // don't attempt to evaluate objects
+        } else {
+          return (next !== current); // has the value changed?
+        }
+      }
+    }, false);
+  }
+  render() {
+    return this.props.children;
+  }
+}
+
+PureRender.propTypes = {
+  children: React.PropTypes.any
+};
+
+class ThemePark extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      themeName: "default",
+      editted: false
+    };
+    // just load once
+    this.themeTexts = {
+      default: this.processCodeText(require("!!raw!./default.example.js")),
+      material: this.processCodeText(require("!!raw!./material.example.js"))
+    };
+  }
+  processCodeText(text) {
+    return text
+            .replace(/\/\* [global|eslint|NOTE](.|[\n])*?\*\//g, "") // remove dev comments
+            .trim(); // remove left-over whitespace
+  }
+  resetTheme(themeName) {
+    this.setState({ themeName });
+    this.setState({ editted: false });
+  }
+  handleUserEdit() {
+    this.setState({ editted: true });
+  }
+  getCodeText() {
+    return this.themeTexts[this.state.themeName];
+  }
+  renderMenu() {
+    const menuClass = "ThemeParkMenu";
+    const barClass = "ThemeParkMenuBar";
+    const themeNameClass = "ThemeParkThemeName";
+    const styleRules = {
+      [`.${menuClass}`]: {
+        backgroundColor: VictorySettings.whiteSand,
+        margin: "20px -40px -40px"
+      },
+      [`.${menuClass} button`]: {
+        // remove button styling
+        margin: 0,
+        padding: 0,
+        border: 0,
+        background: "transparent",
+        fontSize: "inherit",
+        fontFamily: "inherit",
+        cursor: "pointer",
+        outline: "none",
+        // make it do the thing
+        marginLeft: "25px",
+        textAlign: "center"
+      },
+      [`.${menuClass} button:hover`]: {
+        textDecoration: "underline"
+      },
+      [`.${menuClass} h3.${themeNameClass}`]: { // theme name
+        textTransform: "none",
+        textAlign: "center",
+        padding: 30,
+        margin: "0 40px",
+        maxWidth: "none"
+      },
+      [`.${menuClass} .${barClass}`]: { // menu
+        padding: "17px 0 17px 40px",
+        backgroundColor: "rgba(0,0,0,0)"
+      },
+      [`.${menuClass} .${barClass}:hover`]: {
+        backgroundColor: "rgba(0,0,0,0.05)"
+      },
+      mediaQueries: {
+        [VictorySettings.mediaQueries.large]: {
+          [`.${menuClass}`]: {
+            margin: "20px -60px -40px"
+          }
+        }
+      }
+    };
+    return (
+      <div className={menuClass}>
+        <div className={barClass}>
+          <button onClick={this.resetTheme.bind(this, "default")}>
+            reset to <b>default</b>
+          </button>
+          <button onClick={this.resetTheme.bind(this, "material")}>
+            reset to <b>material</b>
+          </button>
+        </div>
+        <h3 className={themeNameClass}>
+          {this.state.themeName}
+          {this.state.editted ? "*" : ""}
+        </h3>
+        <Style rules={styleRules}/>
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div className="Recipe">
+        <div className="Overview">
+          <h1>Theme Park</h1>
+          <p>
+            Try out the Victory themes and make your own.
+          </p>
+        </div>
+        {this.renderMenu()}
+        <PureRender themeName={this.state.themeName} editted={this.state.editted}>
+          <pre>
+            <div className="Interactive" onKeyPress={this.handleUserEdit.bind(this)}>
+              <Playground
+                codeText={this.getCodeText()}
+                scope={{
+                  React,
+                  ReactDOM,
+                  assign,
+                  DemoVictoryComponent
+                }}
+                theme="elegant"
+                noRender={false}
+              />
+            </div>
+          </pre>
+        </PureRender>
+      </div>
+    );
+  }
+}
+
+export default Radium(ThemePark);

--- a/src/screens/recipes/components/theme-park/material.example.js
+++ b/src/screens/recipes/components/theme-park/material.example.js
@@ -1,0 +1,200 @@
+/* NOTE
+  all one-line star comments starting with "eslint", "global", or "NOTE"
+  will be removed before displaying this document to the user
+*/
+/* global React, ReactDOM, DemoVictoryComponent, mountNode, assign */
+
+/*
+  "material" theme
+  Try changing the theme. You could start with `colors` or `fontSize`.
+*/
+
+// Colors
+const deepOrange600 = "#F4511E";
+const yellow200 = "#FFF59D";
+const lime300 = "#DCE775";
+const lightGreen500 = "#8BC34A";
+const teal700 = "#00796B";
+const cyan900 = "#006064";
+const colors = [
+  deepOrange600,
+  yellow200,
+  lime300,
+  lightGreen500,
+  teal700,
+  cyan900
+];
+const blueGrey50 = "#ECEFF1";
+const blueGrey300 = "#90A4AE";
+const blueGrey700 = "#455A64";
+const grey900 = "#212121";
+
+// Typography
+const sansSerif = "'Roboto', 'Helvetica Neue', Helvetica, sans-serif";
+const letterSpacing = "normal";
+const fontSize = 16;
+
+// Layout
+const padding = 8;
+const baseProps = {
+  width: 350,
+  height: 350
+};
+
+// Labels
+const baseLabelStyles = {
+  fontFamily: sansSerif,
+  fontSize,
+  letterSpacing,
+  padding,
+  fill: blueGrey700
+};
+
+// Strokes
+const strokeDasharray = "10, 5";
+const strokeLinecap = "round";
+const strokeLinejoin = "round";
+
+// Put it all together...
+const theme = {
+  area: {
+    data: {
+      fill: grey900
+    },
+    labels: baseLabelStyles,
+    parent: {}
+  },
+  axis: {
+    axis: {
+      fill: "none",
+      stroke: blueGrey300,
+      strokeWidth: 2,
+      strokeLinecap,
+      strokeLinejoin
+    },
+    axisLabel: assign({}, baseLabelStyles,
+      {
+        padding,
+        stroke: "transparent"
+      }),
+    grid: {
+      fill: "none",
+      stroke: blueGrey50,
+      strokeDasharray,
+      strokeLinecap,
+      strokeLinejoin
+    },
+    ticks: {
+      fill: "none",
+      padding,
+      size: 5,
+      stroke: blueGrey300,
+      strokeWidth: 1,
+      strokeLinecap,
+      strokeLinejoin
+    },
+    tickLabels: assign({}, baseLabelStyles,
+      {
+        fill: blueGrey700,
+        stroke: "transparent"
+      })
+  },
+  bar: {
+    data: {
+      fill: blueGrey700,
+      opacity: 1,
+      padding,
+      stroke: "transparent",
+      strokeWidth: 0,
+      width: 5
+    },
+    labels: baseLabelStyles,
+    parent: {}
+  },
+  candlestick: {
+    data: {
+      stroke: blueGrey700
+    },
+    labels: baseLabelStyles,
+    parent: {},
+    props: assign({}, baseProps,
+      {
+        candeColors: {
+          positive: "#ffffff",
+          negative: blueGrey700
+        }
+      })
+  },
+  errorbar: {
+    data: {
+      fill: "none",
+      opacity: 1,
+      stroke: blueGrey700,
+      strokeWidth: 2
+    },
+    labels: assign({}, baseLabelStyles,
+      {
+        stroke: "transparent",
+        strokeWidth: 0,
+        textAnchor: "start"
+      }),
+    parent: {}
+  },
+  line: {
+    data: {
+      fill: "none",
+      opacity: 1,
+      stroke: blueGrey700,
+      strokeWidth: 2
+    },
+    labels: assign({}, baseLabelStyles,
+      {
+        stroke: "transparent",
+        strokeWidth: 0,
+        textAnchor: "start"
+      }),
+    parent: {}
+  },
+  pie: {
+    props: assign({}, baseProps,
+      {
+        colorScale: colors
+      }),
+    style: {
+      data: {
+        padding,
+        stroke: blueGrey50,
+        strokeWidth: 1
+      },
+      labels: assign({}, baseLabelStyles,
+        {
+          padding: 95,
+          stroke: "transparent",
+          strokeWidth: 0,
+          textAnchor: "middle"
+        }),
+      parent: {}
+    }
+  },
+  scatter: {
+    data: {
+      fill: blueGrey700,
+      opacity: 1,
+      stroke: "transparent",
+      strokeWidth: 0
+    },
+    labels: Object.assign({}, baseLabelStyles,
+      {
+        stroke: "transparent",
+        textAnchor: "middle"
+      }),
+    parent: {}
+  },
+  props: Object.assign({}, baseProps,
+    {
+      colorScale: colors
+    }
+  )
+};
+
+ReactDOM.render(<DemoVictoryComponent theme={theme}/>, mountNode);


### PR DESCRIPTION
Moving Theme Park from victory-examples as it makes much more sense here. All custom styling and layout for it (because it isn't a standard Ecology Playground like the other recipes) is contained in the same file.

I'd love feedback on file location and radium styling, in addition to general thoughts.

❤️ chris
