### PR TITLE
Bug: Add base to path name to GA

### DIFF
--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -27,8 +27,9 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
   // Add Google Analytics tracking for each page
   ReactGA.initialize("UA-43290258-1");
   history.listen((location) => {
-    ReactGA.set({ page: location.pathname });
-    ReactGA.pageview(location.pathname);
+    const fullLocation = basename + location.pathname;
+    ReactGA.set({ page: fullLocation });
+    ReactGA.pageview(fullLocation);
   });
   render(
     <Router


### PR DESCRIPTION
Checked Google Analytics while browsing the site and the base name was still missing, but each page view was showing up (yay)
- Append `basename` to the path, so the full route should show up correctly in GA now! 

/cc @kylecesmat @chrisbolin 
