### PR TITLE
Update Examples' Style; Add Shared Events

### DIFF
--- a/src/components/config-recipes.js
+++ b/src/components/config-recipes.js
@@ -3,6 +3,7 @@ import CustomDataComponent from "../screens/recipes/components/custom-data-compo
 import CustomStyles from "../screens/recipes/components/custom-styles/docs";
 import MultipleAxes from "../screens/recipes/components/multiple-axes/docs";
 import Tooltip from "../screens/recipes/components/tooltip/docs";
+import SharedEvents from "../screens/recipes/components/shared-events/docs";
 import CandlestickDashboard from "../screens/recipes/components/candlestick-dashboard/docs";
 import ThemePark from "../screens/recipes/components/theme-park";
 
@@ -29,7 +30,7 @@ export const recipesComponents = [
     category: "customize",
     docs: MultipleAxes
   }, {
-    text: "Styles",
+    text: "Custom Styles",
     slug: "custom-styles",
     category: "customize",
     docs: CustomStyles
@@ -43,5 +44,10 @@ export const recipesComponents = [
     slug: "tooltip",
     category: "events",
     docs: Tooltip
+  }, {
+    text: "Shared Events",
+    slug: "shared-events",
+    category: "events",
+    docs: SharedEvents
   }
 ];

--- a/src/screens/recipes/components/custom-central-axis/ecology.md
+++ b/src/screens/recipes/components/custom-central-axis/ecology.md
@@ -2,6 +2,24 @@ Custom Central Axis
 =============
 
 ```playground_norender
+// Data sets
+const dataA = [
+  {x: "Personal Drones", y: 57},
+  {x: "Smart Thermostat", y: 40},
+  {x: "Television", y: 38},
+  {x: "Smartwatch", y: 37},
+  {x: "Fitness Monitor", y: 25},
+  {x: "Tablet", y: 19},
+  {x: "Camera", y: 15},
+  {x: "Laptop", y: 13},
+  {x: "Phone", y: 12}
+];
+
+const dataB = dataA.map(point => {
+  const y = Math.round(point.y + 3 * (Math.random() - 0.5));
+  return { ...point, y };  
+});
+
 class CentralAxis extends React.Component {
   render() {
     return (
@@ -17,7 +35,6 @@ class CentralAxis extends React.Component {
           */
           height={300}
           width={500}
-          padding={50}
           standalone={false}
           style={{
             data: {width: 20},
@@ -26,34 +43,14 @@ class CentralAxis extends React.Component {
         >
           <VictoryBar
             style={{data: {fill: "tomato"}}}
-            data={[
-              {x: "Smartphone", y: 57},
-              {x: "Laptop", y: 36},
-              {x: "Televsion", y: 38},
-              {x: "Tablet", y: 38},
-              {x: "Fitness Monitor", y: 12},
-              {x: "Smartwatch", y: 12},
-              {x: "Surveillance Camera", y: 10},
-              {x: "Smart Thermostat", y: 9},
-              {x: "Personal Drones", y: 6}
-            ]}
+            data={dataA}
             x={"x"}
             y={(data) => (-Math.abs(data.y))}
             labels={(data) => (`${Math.abs(data.y)}%`)}
           />
           <VictoryBar
             style={{data: {fill: "orange"}}}
-            data={[
-              {x: "Smartphone", y: 48},
-              {x: "Laptop", y: 30},
-              {x: "Television", y: 30},
-              {x: "Tablet", y: 29},
-              {x: "Fitness Monitor", y: 13},
-              {x: "Smartwatch", y: 13},
-              {x: "Surveillance Camera", y: 11},
-              {x: "Smart Thermostat", y: 9},
-              {x: "Personal Drones", y: 7}
-            ]}
+            data={dataB}
             labels={(data) => (`${Math.abs(data.y)}%`)}
           />
         </VictoryStack>
@@ -61,11 +58,10 @@ class CentralAxis extends React.Component {
         <VictoryAxis dependentAxis
           height={300}
           width={500}
-          padding={50}
           style={{
             axis: {stroke: "transparent"},
             ticks: {stroke: "transparent"},
-            tickLabels: {fontSize: 7, fill: "black"}
+            tickLabels: {fontSize: 11, fill: "black"}
           }}
           /*
             Use a custom tickLabelComponent with an absolutely positioned x value
@@ -73,20 +69,10 @@ class CentralAxis extends React.Component {
             y values are still provided by VictoryAxis for each tick
           */
           tickLabelComponent={
-            <VictoryLabel x={250} textAnchor="middle" verticalAnchor="middle"/>
+            <VictoryLabel x={245} dy={-0.5} textAnchor="middle" verticalAnchor="start"/>
           }
           standalone={false}
-          tickValues={[
-            "Smartphone",
-            "Laptop",
-            "Television",
-            "Tablet",
-            "Fitness Monitor",
-            "Smartwatch",
-            "Surveillance Camera",
-            "Smart Thermostat",
-            "Personal Drones"
-          ]}
+          tickValues={dataA.map(point => point.x).reverse()}
         />
       </svg>
     );

--- a/src/screens/recipes/components/custom-data-component/ecology.md
+++ b/src/screens/recipes/components/custom-data-component/ecology.md
@@ -41,8 +41,7 @@ class CustomDataComponent extends React.Component {
         boxSizing: "border-box",
         display: "block",
         width: "100%",
-        height: "100%",
-        padding: 50
+        height: "100%"
       }
     };
   }

--- a/src/screens/recipes/components/custom-styles/ecology.md
+++ b/src/screens/recipes/components/custom-styles/ecology.md
@@ -42,7 +42,6 @@ class CustomTheme extends React.Component {
   }
 
   getStyles() {
-    const BABY_BLUE_COLOR = "#ccdee8";
     const BLUE_COLOR = "#00a3de";
     const RED_COLOR = "#7c270b";
 
@@ -51,7 +50,6 @@ class CustomTheme extends React.Component {
         boxSizing: "border-box",
         display: "inline",
         padding: 0,
-        backgroundColor: BABY_BLUE_COLOR,
         fontFamily: "'Fira Sans', sans-serif",
         width: "100%",
         height: "auto"
@@ -167,6 +165,12 @@ class CustomTheme extends React.Component {
         viewBox="0 0 450 350"
       >
         <rect
+          x="0" y="0"
+          width="450" height="350"
+          fill="#ccdee8"
+        />
+
+        <rect
           x="0"
           y="0"
           width="10"
@@ -183,7 +187,7 @@ class CustomTheme extends React.Component {
         />
 
         <VictoryLabel
-          x={430} y={27}
+          x={430} y={25}
           textAnchor="middle"
           verticalAnchor="end"
           style={styles.labelNumber}

--- a/src/screens/recipes/components/multiple-axes/ecology.md
+++ b/src/screens/recipes/components/multiple-axes/ecology.md
@@ -9,8 +9,7 @@ class MultipleAxes extends React.Component {
         boxSizing: "border-box",
         display: "block",
         width: "100%",
-        height: "100%",
-        padding: 50
+        height: "100%"
       }
     };
   }

--- a/src/screens/recipes/components/shared-events/ecology.md
+++ b/src/screens/recipes/components/shared-events/ecology.md
@@ -4,7 +4,6 @@ Shared Events
 ```playground_norender
 class SharedEvents extends React.Component {
   render() {
-    const parentStyle = {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"};
     const lineData = [
       {x: 1, y: 39},
       {x: 2, y: 31},
@@ -35,7 +34,7 @@ class SharedEvents extends React.Component {
       {x: 20, y: 15, label: "Oct 2014"}
     ];
     return (
-          <svg width={1000} height={600} style={{parent: parentStyle}}>
+          <svg width={700} height={400} viewBox="0 0 800 400">
             <VictorySharedEvents
               events={[
                 {
@@ -90,26 +89,25 @@ class SharedEvents extends React.Component {
             >
               <VictoryBar
                 name="bar"
-                width={900}
-                height={600}
+                width={700}
+                height={400}
                 data={barData}
-                style={{data: {fill: "tomato"}, labels: {fill: "transparent"}}}
+                style={{data: {fill: "tomato", width: 25}, labels: {fill: "transparent"}}}
                 standalone={false}
               />
               <VictoryLine
                 name={"line"}
                 data={lineData}
-                width={900}
-                height={600}
+                width={700}
+                height={400}
                 standalone={false}
                 domain={{y: [0, 100]}}
                 style={{data: {stroke: "transparent"}}}
               />
               <VictoryAxis
                 standalone={false}
-                width={900}
-                label="Year"
-                height={600}
+                width={700}
+                height={400}
                 tickValues={["2010", "2011", "2012", "2013", "2014", "2015"]}
               />
           </VictorySharedEvents>

--- a/static-routes.js
+++ b/static-routes.js
@@ -22,5 +22,6 @@ module.exports = [
   "/recipes/multiple-axes",
   "/recipes/candlestick-dashboard",
   "/recipes/tooltip",
+  "/recipes/shared-events",
   "/recipes/theme-park"
 ];


### PR DESCRIPTION
Last PR to close out https://github.com/FormidableLabs/victory-examples/issues/23

- Merging in new styles from `victory-examples`. Mainly removing padding.
- Add the (forgotten) Shared Events example to the navigation bar