### PR TITLE
suggestions for content edits to lander main page

### DIFF
--- a/src/screens/home/components/hero.js
+++ b/src/screens/home/components/hero.js
@@ -141,7 +141,7 @@ class Hero extends React.Component {
           }}
         >
           <RadiumLink style={styles.linkGettingStarted} to="/docs">
-            Getting Started Guide <Icon glyph="internal-link" />
+            Get Started with Victory <Icon glyph="internal-link" />
           </RadiumLink>
         </div>
       </div>

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -5,8 +5,8 @@ const RadiumLink = Radium(Link);
 
 // Common
 import { VictorySettings } from "formidable-landers";
-import { components } from "../../components/config";
-import { recipesComponents } from "../../components/config-recipes";
+// import { components } from "../../components/config";
+// import { recipesComponents } from "../../components/config-recipes";
 import Icon from "../../components/icon";
 import TitleMeta from "../../components/title-meta";
 import Footer from "../../components/footer";
@@ -90,6 +90,28 @@ class Home extends React.Component {
         letterSpacing: "0.2em",
         lineHeight: 1,
         textTransform: "uppercase"
+      },
+      linkGettingStarted: {
+        borderStyle: "solid",
+        borderWidth: "39px 41px",
+        borderImageSource: `url("./static/btn-border.svg")`,
+        borderImageSlice: "39 41",
+        borderImageRepeat: "repeat stretch",
+        color: VictorySettings.red,
+        display: "inline-block",
+        fontFamily: VictorySettings.sansSerif,
+        fontSize: "0.75em",
+        fontWeight: "normal",
+        letterSpacing: "0.2em",
+        lineHeight: 1,
+        textTransform: "uppercase",
+        padding: "30px 24px",
+        width: "100%",
+        transition: "color 300ms ease-out",
+        ":hover": {
+          color: VictorySettings.mud,
+          transition: "color 300ms ease"
+        }
       }
     };
   }
@@ -135,50 +157,65 @@ class Home extends React.Component {
           <Hero />
           <Benefits />
 
-          <h2 style={styles.copy}>
-            Let’s Get Started!
-          </h2>
-          <p style={styles.copy}>
-            Victory documentation is automatically generated from GitHub, so it’s always in sync. Dig in deeper knowing you’re reading about the latest release of Victory.
-          </p>
-          <h3 style={styles.copy}>Documentation</h3>
-          <div style={styles.columns}>
-            <ul style={styles.list}>
-              <li style={styles.headingCategory}>Core</li>
-              {this.renderComponents(components, "docs", "core")}
-              <li style={[styles.listItem, {color: VictorySettings.darkerSand}]}>
-                VictoryTooltip <abbr title="Coming soon"><Icon glyph="coming-soon" /></abbr>
-              </li>
-            </ul>
-            <ul style={styles.list}>
-              <li style={styles.headingCategory}>Chart</li>
-              <li key="victory-chart2" style={styles.listItem}>
-                <RadiumLink to="docs/victory-chart">
-                  VictoryChart <Icon glyph="internal-link" />
-                </RadiumLink>
-              </li>
-              <ul style={styles.nestedList}>
-                {this.renderComponents(components, "docs", "chart")}
-              </ul>
-            </ul>
-            <ul style={styles.list}>
-              <li style={styles.headingCategory}>More</li>
-              {this.renderComponents(components, "docs", "more")}
-            </ul>
-          </div>
-          <h3 style={styles.copy}>Recipes</h3>
-          <p style={styles.copy}>
-            The <RadiumLink to="/recipes">Recipes&nbsp;<Icon glyph="internal-link" /></RadiumLink> show examples of customized, complex, and extendable charts.
-          </p>
-          <div style={styles.columns}>
-            <ul style={styles.list}>
-              <li style={styles.headingCategory}>Customize</li>
-              {this.renderComponents(recipesComponents, "recipes", "customize")}
-            </ul>
-            <ul style={styles.list}>
-              <li style={styles.headingCategory}>Events</li>
-              {this.renderComponents(recipesComponents, "recipes", "events")}
-            </ul>
+          {/*<h2 style={styles.copy}>
+                      Let’s Get Started!
+                    </h2>
+                    <p style={styles.copy}>
+                      Victory documentation is automatically generated from GitHub, so it’s always in sync. Dig in deeper knowing you’re reading about the latest release of Victory.
+                    </p>
+                    <h3 style={styles.copy}>Documentation</h3>
+                    <div style={styles.columns}>
+                      <ul style={styles.list}>
+                        <li style={styles.headingCategory}>Core</li>
+                        {this.renderComponents(components, "docs", "core")}
+                        <li style={[styles.listItem, {color: VictorySettings.darkerSand}]}>
+                          VictoryTooltip <abbr title="Coming soon"><Icon glyph="coming-soon" /></abbr>
+                        </li>
+                      </ul>
+                      <ul style={styles.list}>
+                        <li style={styles.headingCategory}>Chart</li>
+                        <li key="victory-chart2" style={styles.listItem}>
+                          <RadiumLink to="docs/victory-chart">
+                            VictoryChart <Icon glyph="internal-link" />
+                          </RadiumLink>
+                        </li>
+                        <ul style={styles.nestedList}>
+                          {this.renderComponents(components, "docs", "chart")}
+                        </ul>
+                      </ul>
+                      <ul style={styles.list}>
+                        <li style={styles.headingCategory}>More</li>
+                        {this.renderComponents(components, "docs", "more")}
+                      </ul>
+                    </div>
+                    <h3 style={styles.copy}>Recipes</h3>
+                    <p style={styles.copy}>
+                      The <RadiumLink to="/recipes">Recipes&nbsp;<Icon glyph="internal-link" /></RadiumLink> show examples of customized, complex, and extendable charts.
+                    </p>
+                    <div style={styles.columns}>
+                      <ul style={styles.list}>
+                        <li style={styles.headingCategory}>Customize</li>
+                        {this.renderComponents(recipesComponents, "recipes", "customize")}
+                      </ul>
+                      <ul style={styles.list}>
+                        <li style={styles.headingCategory}>Events</li>
+                        {this.renderComponents(recipesComponents, "recipes", "events")}
+                      </ul>
+                    </div>*/}
+
+          <div
+            style={{
+              display: "block",
+              fontFamily: VictorySettings.sansSerif,
+              marginTop: `${VictorySettings.gutter}px`,
+              marginRight: "3vw",
+              marginLeft: "3vw",
+              textAlign: "center"
+            }}
+          >
+            <RadiumLink style={styles.linkGettingStarted} to="/docs">
+              Get Started with Victory <Icon glyph="internal-link" />
+            </RadiumLink>
           </div>
 
           <h3 style={styles.copy}>Source Code</h3>
@@ -195,12 +232,12 @@ class Home extends React.Component {
               FormidableLabs/victory&nbsp;<Icon glyph="external-link" />
             </a>.
           </p>
-          <h3 style={styles.copy}>Upcoming Releases</h3>
-          <p style={styles.copy}>
-            We have a lot planned! Want to make a request for a new feature? See our <a href="https://github.com/FormidableLabs/victory/blob/master/ROADMAP.md">
-              Roadmap&nbsp;<Icon glyph="external-link" />
-          </a>.
-          </p>
+          {/*<h3 style={styles.copy}>Upcoming Releases</h3>
+                    <p style={styles.copy}>
+                      We have a lot planned! Want to make a request for a new feature? See our <a href="https://github.com/FormidableLabs/victory/blob/master/ROADMAP.md">
+                        Roadmap&nbsp;<Icon glyph="external-link" />
+                    </a>.
+                    </p>*/}
 
           <Companies style={styles.copy} />
           <Footer />

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -156,53 +156,6 @@ class Home extends React.Component {
         <section style={styles.section} className="playgroundsMaxHeight">
           <Hero />
           <Benefits />
-
-          {/*<h2 style={styles.copy}>
-                      Let’s Get Started!
-                    </h2>
-                    <p style={styles.copy}>
-                      Victory documentation is automatically generated from GitHub, so it’s always in sync. Dig in deeper knowing you’re reading about the latest release of Victory.
-                    </p>
-                    <h3 style={styles.copy}>Documentation</h3>
-                    <div style={styles.columns}>
-                      <ul style={styles.list}>
-                        <li style={styles.headingCategory}>Core</li>
-                        {this.renderComponents(components, "docs", "core")}
-                        <li style={[styles.listItem, {color: VictorySettings.darkerSand}]}>
-                          VictoryTooltip <abbr title="Coming soon"><Icon glyph="coming-soon" /></abbr>
-                        </li>
-                      </ul>
-                      <ul style={styles.list}>
-                        <li style={styles.headingCategory}>Chart</li>
-                        <li key="victory-chart2" style={styles.listItem}>
-                          <RadiumLink to="docs/victory-chart">
-                            VictoryChart <Icon glyph="internal-link" />
-                          </RadiumLink>
-                        </li>
-                        <ul style={styles.nestedList}>
-                          {this.renderComponents(components, "docs", "chart")}
-                        </ul>
-                      </ul>
-                      <ul style={styles.list}>
-                        <li style={styles.headingCategory}>More</li>
-                        {this.renderComponents(components, "docs", "more")}
-                      </ul>
-                    </div>
-                    <h3 style={styles.copy}>Recipes</h3>
-                    <p style={styles.copy}>
-                      The <RadiumLink to="/recipes">Recipes&nbsp;<Icon glyph="internal-link" /></RadiumLink> show examples of customized, complex, and extendable charts.
-                    </p>
-                    <div style={styles.columns}>
-                      <ul style={styles.list}>
-                        <li style={styles.headingCategory}>Customize</li>
-                        {this.renderComponents(recipesComponents, "recipes", "customize")}
-                      </ul>
-                      <ul style={styles.list}>
-                        <li style={styles.headingCategory}>Events</li>
-                        {this.renderComponents(recipesComponents, "recipes", "events")}
-                      </ul>
-                    </div>*/}
-
           <div
             style={{
               display: "block",
@@ -232,13 +185,6 @@ class Home extends React.Component {
               FormidableLabs/victory&nbsp;<Icon glyph="external-link" />
             </a>.
           </p>
-          {/*<h3 style={styles.copy}>Upcoming Releases</h3>
-                    <p style={styles.copy}>
-                      We have a lot planned! Want to make a request for a new feature? See our <a href="https://github.com/FormidableLabs/victory/blob/master/ROADMAP.md">
-                        Roadmap&nbsp;<Icon glyph="external-link" />
-                    </a>.
-                    </p>*/}
-
           <Companies style={styles.copy} />
           <Footer />
         </section>


### PR DESCRIPTION
cc/ @paulathevalley 

This makes the following edits to the main page for the Victory lander:
1) Removes the index of docs links from the bottom of the webpage (to be replaced by a second large call to action to get started with victory and the updated header with a docs link)
2) Removes the link to the Victory Roadmap (since Lauren is removing or significantly editing how this is handled. Can be added back in later if wanted but I think it should live in About at that point)
3) Adds a second large call to "Get started with Victory" at the bottom of the feature list. Since the content is still on the longer side, I think it's helpful for users to have two options to click to minimize scrolling. Also changed the language of the link to be more encompassing than just "Getting Started Guide".

I think this is all in line with examples Elise had shared with me of landers she really liked, without getting rid of any of the substantive existing content, which I really like. Would love to hear your thoughts, Paula! I've commented out stuff that would be removed for now and will only actually remove it if you think this seems reasonable. 