### PR TITLE
Fix visual bug on homepage on mobile

### DIFF
--- a/src/screens/home/components/benefits.js
+++ b/src/screens/home/components/benefits.js
@@ -149,7 +149,7 @@ class Benefits extends React.Component {
           <div
             style={{
               display: "flex",
-              flex: "1 0 600px",
+              flex: "1 0 300px",
               flexDirection: "row",
               flexWrap: "nowrap",
               justifyContent: "center"

--- a/src/screens/home/components/companies.js
+++ b/src/screens/home/components/companies.js
@@ -7,7 +7,6 @@ import OOKLA from "../../../../static/logo-ookla.svg";
 import VIACOM from "../../../../static/logo-viacom.svg";
 import POSTMARK from "../../../../static/logo-postmark.svg";
 import FIVETHIRTYEIGHT from "../../../../static/logo-fivethirtyeight.svg";
-import ICONHEART from "../../../../static/icon-heart.svg";
 
 class Companies extends React.Component {
   getStyles() {
@@ -23,7 +22,7 @@ class Companies extends React.Component {
         alignItems: "center",
         display: "flex",
         flexWrap: "wrap",
-        justifyContent: "space-around",
+        justifyContent: "space-between",
         listStyleType: "none",
         marginTop: `${VictorySettings.gutter}px`,
         marginLeft: `${VictorySettings.gutter * -2}px`,
@@ -46,7 +45,7 @@ class Companies extends React.Component {
     return (
       <div style={this.props.style}>
         <h2>
-          <span style={styles.heart} dangerouslySetInnerHTML={{__html: ICONHEART}} /> See Victory in use
+          A few of our fans
         </h2>
         <ul style={styles.list}>
           <li style={styles.logo} dangerouslySetInnerHTML={{__html: FIVETHIRTYEIGHT}} />

--- a/src/screens/home/components/demo-native.js
+++ b/src/screens/home/components/demo-native.js
@@ -3,6 +3,7 @@ import Radium from "radium";
 
 // VComponents
 import { VictoryArea, VictoryAxis, VictoryBar, VictoryChart, VictoryStack } from "victory-chart";
+import { VictorySettings } from "formidable-landers";
 
 class Native extends React.Component {
   constructor(props) {
@@ -45,14 +46,17 @@ class Native extends React.Component {
         backgroundPosition: "top center",
         backgroundRepeat: "no-repeat",
         backgroundSize: "100% auto",
-        display: "flex",
+        display: this.props.alt ? "none" : "flex",
         flexDirection: "column",
         flexWrap: "nowrap",
         justifyContent: "space-around",
         margin: "0 20px",
         height: "470px",
         padding: "60px 25px 50px",
-        width: "250px"
+        width: "250px",
+        [`@media ${VictorySettings.mediaQueries.small}`]: {
+          display: "flex"
+        }
       }
     };
   }


### PR DESCRIPTION
Resolves visual bug reported this morning in slack. 

The second native example disappears on mobile, and is shown otherwise. 

Also modified the copy for the Companies section with @ebrillhart’s direction... it’s the cutest and least awful of the options, so it's the best we got.

 