### PR TITLE
Change 'Errorbar' to 'ErrorBar'

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -10,7 +10,7 @@ import VLineDocs from "victory-chart/docs/victory-line/docs";
 import VPieDocs from "victory-pie/docs/victory-pie/docs";
 import VScatterDocs from "victory-chart/docs/victory-scatter/docs";
 import VCandlestickDocs from "victory-chart/docs/victory-candlestick/docs";
-import VErrorbarDocs from "victory-chart/docs/victory-errorbar/docs";
+import VErrorBarDocs from "victory-chart/docs/victory-errorbar/docs";
 import VThemeDocs from "victory-chart/docs/victory-theme/docs";
 import VTooltipDocs from "victory-chart/docs/victory-tooltip/docs";
 import VVoronoiDocs from "victory-chart/docs/victory-voronoi/docs";
@@ -47,10 +47,10 @@ export const components = [
     category: "chart",
     docs: VChartDocs
   }, {
-    text: "VictoryErrorbar",
+    text: "VictoryErrorBar",
     slug: "victory-errorbar",
     category: "chart",
-    docs: VErrorbarDocs
+    docs: VErrorBarDocs
   }, {
     text: "VictoryGroup",
     slug: "victory-group",


### PR DESCRIPTION
The component's name is actually `VictoryErrorBar`.  This updates the documentation sidebar link to accurately reflect the name of the component.

|**Before**| **After** |
|-----------|----------|
|![image](https://cloud.githubusercontent.com/assets/13814048/18800620/d538fa28-8192-11e6-979a-904590ab4f0a.png)|![image](https://cloud.githubusercontent.com/assets/13814048/18800727/647e094e-8193-11e6-9cc8-cb9bd4d355e3.png)|

cc/ @paulathevalley @ebrillhart 

