### PR TITLE
Fix bug where the /index.html route would fail to load

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, IndexRoute } from "react-router";
+import { Route, IndexRoute, Redirect } from "react-router";
 
 // Components
 import App from "./components/app";
@@ -16,5 +16,8 @@ module.exports = (
     <Route path="/recipes" component={Recipes}/>
     <Route path="/recipes/:component" component={Recipes} />
     <Route path="/about" component={About} />
+    <Route path="/">
+      <Redirect from="index.html" to="/" />
+    </Route>
   </Route>
 );


### PR DESCRIPTION
Fixes #118 

React Router could not find the `/index.html` route so it would fail to load. This adds a redirect from `/index.html` to the index route `/`.

cc/ @ebrillhart @paulathevalley 