### PR TITLE
Bug: Fix babel error that couldn't resolve extends clause 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/FormidableLabs/victory-docs#readme",
   "devDependencies": {
     "builder-docs-archetype-dev": "^4.1.1",
-    "builder-react-component-dev": "^0.3.5",
     "react-docgen": "2.7.0"
   },
   "dependencies": {
@@ -31,8 +30,6 @@
     "babel-preset-stage-1": "^6.5.0",
     "builder": "^2.10.1",
     "builder-docs-archetype": "^4.1.1",
-    "builder-react-component": "^0.3.5",
-    "builder-victory-component": "^3.1.0",
     "chai": "^3.2.0",
     "ecology": "^1.6.0",
     "formidable-landers": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "builder": "^2.10.1",
     "builder-docs-archetype": "^4.1.1",
     "builder-react-component": "^0.3.5",
+    "builder-victory-component": "^3.1.0",
     "chai": "^3.2.0",
     "ecology": "^1.6.0",
     "formidable-landers": "^5.1.1",
@@ -53,6 +54,6 @@
     "react-router-scroll": "^0.3.2",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "victory": "*"
+    "victory": "latest"
   }
 }


### PR DESCRIPTION
Travis was showing a babel error because it couldn’t resolve the `.babelrc` file that lives in `builder-victory-component`, see errors here:
https://travis-ci.org/FormidableLabs/victory-docs/jobs/171509837#L1894
https://travis-ci.org/FormidableLabs/victory-docs/jobs/171495315#L2015

 This PR adds `builder-victory-component` as a dependency so it’ll resolve (I hope). 
