### PR TITLE
use temporary version with victory zoom reverted

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "react-router-scroll": "^0.4.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "victory": "*"
+    "victory": "0.13.6"
   }
 }


### PR DESCRIPTION
cc/ @paulathevalley 

Rather than reverting to a `0.12.x` version of victory, I've published an `0.13.x` that is pinned to exact deps for victory-core and victory-chart