### PR TITLE
Fix relative asset URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     ]
   },
   "devDependencies": {
-    "builder-docs-archetype-dev": "^4.2.2",
+    "builder-docs-archetype-dev": "^5.0.0",
     "react-docgen": "2.12.1"
   },
   "dependencies": {
     "anchorate": "^1.1.0",
     "babel-preset-stage-1": "^6.5.0",
     "builder": "^3.1.0",
-    "builder-docs-archetype": "^4.2.2",
+    "builder-docs-archetype": "^5.0.0",
     "chai": "^3.2.0",
     "ecology": "^1.6.0",
     "formidable-landers": "^5.1.1",

--- a/src/styles/components/button.css
+++ b/src/styles/components/button.css
@@ -92,7 +92,7 @@
 .btn--fancy {
   border-style: solid;
   border-width: 39px 41px;
-  border-image-source: url("../../static/btn-border.svg");
+  border-image-source: url("../../../static/btn-border.svg");
   border-image-slice: 39 41;
   border-image-repeat: repeat stretch;
   color: var(--red);

--- a/src/styles/components/home.css
+++ b/src/styles/components/home.css
@@ -26,7 +26,7 @@
 }
 
 .Demo-bg {
-  /*background-image: url("/static/hero@2x.png"); TOOD: fix import of assets in .css files*/
+  background-image: url("../../../static/hero@2x.png");
   background-position: top center;
   background-repeat: no-repeat;
   background-size: 100% auto;

--- a/src/styles/components/markdown.css
+++ b/src/styles/components/markdown.css
@@ -28,7 +28,7 @@
 }
 
 .Anchor {
-  background: url("../../static/icon-link.svg") 0 no-repeat;
+  background: url("../../../static/icon-link.svg") 0 no-repeat;
   border-bottom: 0 !important;
   position: absolute !important;
   top: 0;


### PR DESCRIPTION
When combined with FormidableLabs/builder-docs-archetype#38, this fixes #215. These asset paths are now relative to the file in which they are requested, just like normal `require()` rules – made possible by the `postcss-url` plugin.

/cc @paulathevalley @ryan-roemer 