### PR TITLE
Provide instruction on time series

### DIFF
--- a/docs/victory-area/docs.md
+++ b/docs/victory-area/docs.md
@@ -117,7 +117,7 @@ The `interpolation` prop determines how data points should be connected when cre
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-axis/docs.md
+++ b/docs/victory-axis/docs.md
@@ -99,7 +99,7 @@ The `standalone` props specifies whether the component should be rendered in a i
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt").
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"). For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`
 

--- a/docs/victory-bar/docs.md
+++ b/docs/victory-bar/docs.md
@@ -119,7 +119,7 @@ or horizontal if the prop is set to true.
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-candlestick/docs.md
+++ b/docs/victory-candlestick/docs.md
@@ -109,7 +109,7 @@ Candle colors are significant in candlestick charts, with colors indicating whet
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-chart/docs.md
+++ b/docs/victory-chart/docs.md
@@ -51,7 +51,7 @@ The `standalone` props specifies whether the component should be rendered in a i
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryChart` controls the `scale` prop of its children.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryChart` controls the `scale` prop of its children. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-errorbar/docs.md
+++ b/docs/victory-errorbar/docs.md
@@ -119,7 +119,7 @@ The `borderWidth` prop sets the border width of the error bars. `borderWidth` wi
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-group/docs.md
+++ b/docs/victory-group/docs.md
@@ -129,7 +129,7 @@ The `offset` prop derermines the number of pixels each element in a group should
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryGroup` controls the `scale` prop of its children.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryGroup` controls the `scale` prop of its children. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-line/docs.md
+++ b/docs/victory-line/docs.md
@@ -117,7 +117,7 @@ The `interpolation` prop determines how data points should be connected when cre
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-scatter/docs.md
+++ b/docs/victory-scatter/docs.md
@@ -131,7 +131,7 @@ The `maxBubbleSize` prop sets an upper limit for scaling data points in a bubble
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-stack/docs.md
+++ b/docs/victory-stack/docs.md
@@ -65,7 +65,7 @@ The `xOffset` prop is used for grouping stacks of bars. This prop will be set by
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryStack` controls the `scale` prop of its children.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. `VictoryStack` controls the `scale` prop of its children. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 

--- a/docs/victory-voronoi/docs.md
+++ b/docs/victory-voronoi/docs.md
@@ -115,7 +115,7 @@ The `size` prop determines the maximum size of each voronoi area. When this prop
 
 ### scale
 
-The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y.
+The `scale` prop determines which scales your chart should use. This prop can be given as a string specifying a supported scale ("linear", "time", "log", "sqrt"), or as an object with scales specified for x and y. For "time" scales, data points should be `Date` objects or `getTime()` ints.
 
 *examples:* `scale="time"`, `scale={{x: "linear", y: "log"}}`
 


### PR DESCRIPTION
My data was fresh from the server as strings ("2017-02-21 08:32:21.000") and therefore wasn't rendering correctly. This might help the next person format data a bit faster. I've tested Date() objects and ints provided by getTime() and they appear to render identically. (Whereas rendering a date string is a mess.)