### PR TITLE
Fix document titles for components

### DIFF
--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -40,8 +40,8 @@ class Docs extends React.Component {
     this.setState({tocArray});
   }
 
-  renderContent(activePage) {
-    if (activePage === "index") {
+  renderContent(activePageConf) {
+    if (activePageConf.slug === "index") {
       return (
         <div className="Markdown playgroundsMaxHeight">
           <a href="https://github.com/FormidableLabs/victory-docs/blob/master/docs/index.md" className="SubHeading">Edit this page</a>
@@ -55,14 +55,13 @@ class Docs extends React.Component {
         </div>
       );
     }
-    const conf = find(config, { slug: activePage });
-    const markdownDocs = conf.docs;
-    const editUrl = `https://github.com/FormidableLabs/victory-docs/blob/master/docs/${activePage}/docs.md`;
+    const markdownDocs = activePageConf.docs;
+    const editUrl = `https://github.com/FormidableLabs/victory-docs/blob/master/docs/${activePageConf.slug}/docs.md`;
     return (
       <div>
         <a href={editUrl} className="SubHeading">Edit this page</a>
         <Markdown
-          active={activePage}
+          active={activePageConf.slug}
           basename={basename}
           location={this.props.location}
           markdownFile={markdownDocs}
@@ -73,18 +72,18 @@ class Docs extends React.Component {
   }
 
   render() {
-    const activePage = this.props.params.component ?
-      this.props.params.component :
-      "index";
+    const activePageConf = this.props.params.component ?
+      find(config, { slug: this.props.params.component }) :
+      { slug: "index", text: "Victory" };
 
     return (
-      <TitleMeta title="Victory | Documentation">
+      <TitleMeta title={`${activePageConf.text} | Documentation`}>
         <Page
           location={this.props.location}
-          sidebar={activePage}
+          sidebar={activePageConf.slug}
           tocArray={this.state.tocArray}
         >
-          { this.renderContent(activePage) }
+          { this.renderContent(activePageConf) }
         </Page>
       </TitleMeta>
     );

--- a/test/func/spec/docs.spec.js
+++ b/test/func/spec/docs.spec.js
@@ -22,11 +22,19 @@ var validateRelative = function (abs) {
 };
 
 describe("Docs", function () {
-  it("should render a page with proper title", function () {
+  it("should render the index page with the correct title", function () {
     return adapter.client
       .url("/docs")
       .getTitle().then(function (title) {
         expect(title).to.eq("Victory | Documentation");
+      });
+  });
+
+  it("should render a component page with the correct title", function () {
+    return adapter.client
+      .url("/docs/victory-bar")
+      .getTitle().then(function (title) {
+        expect(title).to.eq("VictoryBar | Documentation");
       });
   });
 


### PR DESCRIPTION
I added a test just for `VictoryBar` - I'd like to test every route but importing `config.js` and so on is non-trivial, and a very simple test is better than no test at all I guess :slightly_smiling_face: 

Resolves https://github.com/FormidableLabs/victory-docs/issues/261