### PR TITLE
Container docs: native events and standalone requirement

### DIFF
--- a/docs/victory-brush-container/docs.md
+++ b/docs/victory-brush-container/docs.md
@@ -147,6 +147,31 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 
 *example:* `theme={VictoryTheme.material}`
 
+### onTouchStart (native only)
+
+The optional `onTouchStart` prop takes a function that is called on every touch event on the chart (when using `victory-native`). The most common use of `onTouchStart` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchEnd`.
+
+*example:*
+
+```jsx
+<ScrollView scrollEnabled={this.state.scrollEnabled}>
+  <VictoryChart
+    containerComponent={
+      <VictoryContainer
+        onTouchStart={() => this.setState({ scrollEnabled: false })}
+        onTouchEnd={() => this.setState({ scrollEnabled: true })}
+      />
+    }
+  >
+   <VictoryBar/>
+  </VictoryChart>
+</ScrollView>
+```
+
+### onTouchEnd (native only)
+
+The optional `onTouchEnd` prop takes a function that is called at the conclusion of every touch event on the chart (when using `victory-native`). The most common use of `onTouchEnd` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchStart`.
+
 [VictoryPortal]: https://formidable.com/open-source/victory/docs/victory-portal
 [Portal]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-portal/portal.js
 [react-native-svg]: https://github.com/react-native-community/react-native-svg
@@ -156,3 +181,4 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 [Read more about themes here]: https://formidable.com/open-source/victory/recipes/theme-park
 [VictoryContainer]: https://formidable.com/open-source/victory/docs/victory-container
 [React event handlers]: https://facebook.github.io/react/docs/events.html
+[Synthetic Event]: https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle

--- a/docs/victory-brush-container/docs.md
+++ b/docs/victory-brush-container/docs.md
@@ -15,6 +15,8 @@ disappear after `onMouseUp` events.
 
 `VictoryBrushContainer` may be used with any Victory component that works with an x-y coordinate
 system, and should be added as the `containerComponent` of the top-level component.
+However, the container that uses it must be standalone
+(`standalone={true}`), which is the default for all Victory components.
 
 ```jsx
 <VictoryChart containerComponent={<VictoryBrushContainer/>}>

--- a/docs/victory-container/docs.md
+++ b/docs/victory-container/docs.md
@@ -47,7 +47,7 @@ The `title` prop specifies the title to be applied to the SVG to assist with acc
 
 The `desc` prop specifies the description of the chart/SVG to assist with accessibility for screen readers. The more informative the description, the more usable it will be for people using screen readers.
 
-*example:* `desc="Golden retreivers make up 30%, Labs make up 25%, and other dog breeds are not represented above 5% each."`
+*example:* `desc="Golden retrievers make up 30%, Labs make up 25%, and other dog breeds are not represented above 5% each."`
 
 ### portalComponent
 

--- a/docs/victory-container/docs.md
+++ b/docs/victory-container/docs.md
@@ -63,6 +63,31 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 
 *example:* `theme={VictoryTheme.material}`
 
+### onTouchStart (native only)
+
+The optional `onTouchStart` prop takes a function that is called on every touch event on the chart (when using `victory-native`). The most common use of `onTouchStart` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchEnd`.
+
+*example:*
+
+```jsx
+<ScrollView scrollEnabled={this.state.scrollEnabled}>
+  <VictoryChart
+    containerComponent={
+      <VictoryContainer
+        onTouchStart={() => this.setState({ scrollEnabled: false })}
+        onTouchEnd={() => this.setState({ scrollEnabled: true })}
+      />
+    }
+  >
+   <VictoryBar/>
+  </VictoryChart>
+</ScrollView>
+```
+
+### onTouchEnd (native only)
+
+The optional `onTouchEnd` prop takes a function that is called at the conclusion of every touch event on the chart (when using `victory-native`). The most common use of `onTouchEnd` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchStart`.
+
 [VictoryPortal]: https://formidable.com/open-source/victory/docs/victory-portal
 [Portal]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-portal/portal.js
 [react-native-svg]: https://github.com/react-native-community/react-native-svg
@@ -70,3 +95,4 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 [VictoryTooltip]: https://formidable.com/open-source/victory/docs/victory-tooltip
 [grayscale theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/grayscale.js
 [Read more about themes here]: https://formidable.com/open-source/victory/recipes/theme-park
+[Synthetic Event]: https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle

--- a/docs/victory-selection-container/docs.md
+++ b/docs/victory-selection-container/docs.md
@@ -116,6 +116,31 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 
 *example:* `theme={VictoryTheme.material}`
 
+### onTouchStart (native only)
+
+The optional `onTouchStart` prop takes a function that is called on every touch event on the chart (when using `victory-native`). The most common use of `onTouchStart` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchEnd`.
+
+*example:*
+
+```jsx
+<ScrollView scrollEnabled={this.state.scrollEnabled}>
+  <VictoryChart
+    containerComponent={
+      <VictoryContainer
+        onTouchStart={() => this.setState({ scrollEnabled: false })}
+        onTouchEnd={() => this.setState({ scrollEnabled: true })}
+      />
+    }
+  >
+   <VictoryBar/>
+  </VictoryChart>
+</ScrollView>
+```
+
+### onTouchEnd (native only)
+
+The optional `onTouchEnd` prop takes a function that is called at the conclusion of every touch event on the chart (when using `victory-native`). The most common use of `onTouchEnd` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchStart`.
+
 [VictoryPortal]: https://formidable.com/open-source/victory/docs/victory-portal
 [Portal]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-portal/portal.js
 [react-native-svg]: https://github.com/react-native-community/react-native-svg
@@ -124,3 +149,4 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 [grayscale theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/grayscale.js
 [Read more about themes here]: https://formidable.com/open-source/victory/recipes/theme-park
 [VictoryContainer]: https://formidable.com/open-source/victory/docs/victory-container
+[Synthetic Event]: https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle

--- a/docs/victory-selection-container/docs.md
+++ b/docs/victory-selection-container/docs.md
@@ -13,6 +13,8 @@ disappear after `onMouseUp` events.
 
 `VictorySelectionContainer` may be used with any Victory component that works with an x-y coordinate
 system, and should be added as the `containerComponent` of the top-level component.
+However, the container that uses it must be standalone
+(`standalone={true}`), which is the default for all Victory components.
 
 ```jsx
 <VictoryChart containerComponent={<VictorySelectionContainer/>}>

--- a/docs/victory-voronoi-container/docs.md
+++ b/docs/victory-voronoi-container/docs.md
@@ -10,7 +10,8 @@ like tooltips, to small data points, or charts with very dense or overlapping da
 
 `VictoryVoronoiContainer` may be used with any Victory component that works with an x-y coordinate
 system, and should be added as the `containerComponent` of the top-level component.
-
+However, the container that uses it must be standalone
+(`standalone={true}`), which is the default for all Victory components.
 
 ```jsx
 <VictoryChart containerComponent={<VictoryVoronoiContainer/>}>

--- a/docs/victory-voronoi-container/docs.md
+++ b/docs/victory-voronoi-container/docs.md
@@ -138,6 +138,31 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 
 *example:* `theme={VictoryTheme.material}`
 
+### onTouchStart (native only)
+
+The optional `onTouchStart` prop takes a function that is called on every touch event on the chart (when using `victory-native`). The most common use of `onTouchStart` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchEnd`.
+
+*example:*
+
+```jsx
+<ScrollView scrollEnabled={this.state.scrollEnabled}>
+  <VictoryChart
+    containerComponent={
+      <VictoryContainer
+        onTouchStart={() => this.setState({ scrollEnabled: false })}
+        onTouchEnd={() => this.setState({ scrollEnabled: true })}
+      />
+    }
+  >
+   <VictoryBar/>
+  </VictoryChart>
+</ScrollView>
+```
+
+### onTouchEnd (native only)
+
+The optional `onTouchEnd` prop takes a function that is called at the conclusion of every touch event on the chart (when using `victory-native`). The most common use of `onTouchEnd` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchStart`.
+
 [VictoryPortal]: https://formidable.com/open-source/victory/docs/victory-portal
 [Portal]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-portal/portal.js
 [react-native-svg]: https://github.com/react-native-community/react-native-svg
@@ -147,3 +172,4 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 [Read more about themes here]: https://formidable.com/open-source/victory/recipes/theme-park
 [VictoryContainer]: https://formidable.com/open-source/victory/docs/victory-container
 [voronoi diagram]: https://github.com/d3/d3-voronoi
+[Synthetic Event]: https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle

--- a/docs/victory-zoom-container/docs.md
+++ b/docs/victory-zoom-container/docs.md
@@ -129,6 +129,31 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 
 *example:* `theme={VictoryTheme.material}`
 
+### onTouchStart (native only)
+
+The optional `onTouchStart` prop takes a function that is called on every touch event on the chart (when using `victory-native`). The most common use of `onTouchStart` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchEnd`.
+
+*example:*
+
+```jsx
+<ScrollView scrollEnabled={this.state.scrollEnabled}>
+  <VictoryChart
+    containerComponent={
+      <VictoryContainer
+        onTouchStart={() => this.setState({ scrollEnabled: false })}
+        onTouchEnd={() => this.setState({ scrollEnabled: true })}
+      />
+    }
+  >
+   <VictoryBar/>
+  </VictoryChart>
+</ScrollView>
+```
+
+### onTouchEnd (native only)
+
+The optional `onTouchEnd` prop takes a function that is called at the conclusion of every touch event on the chart (when using `victory-native`). The most common use of `onTouchEnd` is to prevent the chart's parent `ScrollView` from scrolling, so that the chart and container can be interacted with unencumbered. The function accepts a single parameter, `event`, a React Native [Synthetic Event]. Also see `onTouchStart`.
+
 [VictoryPortal]: https://formidable.com/open-source/victory/docs/victory-portal
 [Portal]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-portal/portal.js
 [react-native-svg]: https://github.com/react-native-community/react-native-svg
@@ -138,3 +163,4 @@ component instance. By default, components use a [grayscale theme]. [Read more a
 [Read more about themes here]: https://formidable.com/open-source/victory/recipes/theme-park
 [VictoryContainer]: https://formidable.com/open-source/victory/docs/victory-container
 [See an example of a zoomable chart]: https://formidable.com/open-source/victory/guides/brush-and-zoom
+[Synthetic Event]: https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle

--- a/docs/victory-zoom-container/docs.md
+++ b/docs/victory-zoom-container/docs.md
@@ -6,6 +6,8 @@ x, y axis. Zoom events are controlled by scrolling, and panning events are contr
 
 `VictoryZoomContainer` may be used with any Victory component that works with an x-y coordinate
 system, and should be added as the `containerComponent` of the top-level component.
+However, the container that uses it must be standalone
+(`standalone={true}`), which is the default for all Victory components.
 
 ```jsx
 <VictoryChart containerComponent={<VictoryZoomContainer/>}>


### PR DESCRIPTION
Addresses two issues
https://github.com/FormidableLabs/victory-docs/issues/276 - "evented" containers must be used on standalone charts only
https://github.com/FormidableLabs/victory-docs/issues/277 - document new native props onTouchStart/End