### PR TITLE
#286 Add anchor tags to guides

### DIFF
--- a/src/components/ecology-linkable.js
+++ b/src/components/ecology-linkable.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Ecology from "ecology";
+import { ecologyPlaygroundLoading } from "formidable-landers";
+
+class EcologyLinkable extends React.Component {
+  renderersWithHeading(pathname, otherRenderers) {
+    return {
+      heading: (text, level) => {
+        const escaped = text.toLowerCase().replace(/[^\w]+/g, "-");
+
+        return `<h${level} id="${escaped}"><a class="Anchor" href="${pathname}#${escaped}" aria-hidden="true"></a>${text}</h${level}/>`;
+      },
+      ...otherRenderers
+    };
+  }
+
+  render() {
+    const { scope, overview, location, customRenderers } = this.props;
+    const pathname = location.pathname;
+
+    return (
+      <Ecology
+        playgroundtheme="elegant"
+        overview={overview}
+        scope={scope}
+        customRenderers={this.renderersWithHeading(pathname, customRenderers)}
+      />
+    );
+  }
+}
+
+EcologyLinkable.propTypes = {
+  scope: React.PropTypes.object.isRequired,
+  location: React.PropTypes.object.isRequired,
+  overview: React.PropTypes.string.isRequired,
+  customRenderers: React.PropTypes.object.isRequired
+};
+
+EcologyLinkable.defaultProps = {
+  children: null,
+  customRenderers: {}
+};
+
+export default EcologyLinkable;

--- a/src/components/ecology-linkable.js
+++ b/src/components/ecology-linkable.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Ecology from "ecology";
-import { ecologyPlaygroundLoading } from "formidable-landers";
 
 class EcologyLinkable extends React.Component {
   renderersWithHeading(pathname, otherRenderers) {

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import { VictoryBar, VictoryChart, VictoryAxis, VictoryTheme, VictoryStack } from "victory";
 import Radium from "radium";
 import Prism from "prismjs";
@@ -18,6 +17,7 @@ import { config } from "../../components/config";
 import Page from "../../components/page";
 import Markdown from "../../components/markdown";
 import TitleMeta from "../../components/title-meta";
+import EcologyLinkable from "../../components/ecology-linkable";
 
 class Docs extends React.Component {
   constructor() {
@@ -45,12 +45,12 @@ class Docs extends React.Component {
       return (
         <div className="Markdown playgroundsMaxHeight">
           <a href="https://github.com/FormidableLabs/victory-docs/blob/master/docs/index.md" className="SubHeading">Edit this page</a>
-          <Ecology
+          <EcologyLinkable
             overview={require("!!raw!../../../docs/index.md")}
+            location={this.props.location}
             scope={{
               React, ReactDOM, VictoryBar, VictoryChart, VictoryAxis, VictoryTheme, VictoryStack
             }}
-            playgroundtheme="elegant"
           />
         </div>
       );

--- a/src/screens/guides/components/animations/docs.js
+++ b/src/screens/guides/components/animations/docs.js
@@ -7,13 +7,28 @@ import { ecologyPlaygroundLoading } from "formidable-landers";
 
 export default class AnimationGuide extends React.Component {
   render() {
+    const customRenderers = {
+      heading: (text, level) => {
+        const escapedText = text.toLowerCase().replace(/[^\w]+/g, "-");
+
+        // return `<h${level}><a name="${escaped}"
+        return "<h" + level + " id=\"" + escapedText + "\"><a name=\"" +
+                      escapedText +
+                       "\" class=\"Anchor\" href=\"#" +
+                       escapedText +
+                       "\" aria-hidden=\"true\"></a>FOOBAR: " +
+                        text + "</h" + level + ">";
+      },
+      ...ecologyPlaygroundLoading
+    };
+
     return (
-      <div className="Recipe">
+      <div className="Recipe Markdown">
         <Ecology
           overview={require("!!raw!./ecology.md")}
           scope={{ range, random, React, ReactDOM, VictoryBar, VictoryScatter, VictoryChart }}
           playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
+          customRenderers={customRenderers}
         />
       </div>
     );

--- a/src/screens/guides/components/animations/docs.js
+++ b/src/screens/guides/components/animations/docs.js
@@ -1,36 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import { VictoryBar, VictoryScatter, VictoryChart } from "victory";
 import { range, random } from "lodash";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class AnimationGuide extends React.Component {
   render() {
-    const customRenderers = {
-      heading: (text, level) => {
-        const escapedText = text.toLowerCase().replace(/[^\w]+/g, "-");
-
-        // return `<h${level}><a name="${escaped}"
-        return "<h" + level + " id=\"" + escapedText + "\"><a name=\"" +
-                      escapedText +
-                       "\" class=\"Anchor\" href=\"#" +
-                       escapedText +
-                       "\" aria-hidden=\"true\"></a>FOOBAR: " +
-                        text + "</h" + level + ">";
-      },
-      ...ecologyPlaygroundLoading
-    };
-
     return (
-      <div className="Recipe Markdown">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{ range, random, React, ReactDOM, VictoryBar, VictoryScatter, VictoryChart }}
-          playgroundtheme="elegant"
-          customRenderers={customRenderers}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{ range, random, React, ReactDOM, VictoryBar, VictoryScatter, VictoryChart }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/animations/docs.js
+++ b/src/screens/guides/components/animations/docs.js
@@ -4,13 +4,20 @@ import { VictoryBar, VictoryScatter, VictoryChart } from "victory";
 import { range, random } from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class AnimationGuide extends React.Component {
+class AnimationGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{ range, random, React, ReactDOM, VictoryBar, VictoryScatter, VictoryChart }}
       />
     );
   }
 }
+
+AnimationGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default AnimationGuide;

--- a/src/screens/guides/components/brush-and-zoom/docs.js
+++ b/src/screens/guides/components/brush-and-zoom/docs.js
@@ -1,27 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import {
   VictoryAxis, VictoryChart, VictoryLine, VictoryScatter,
   VictoryBrushContainer, VictoryZoomContainer
 } from "victory";
-import { ecologyPlaygroundLoading } from "formidable-landers";
 import { random, range } from "lodash";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class CustomComponentGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            random, range, React, ReactDOM, VictoryChart, VictoryAxis, VictoryLine, VictoryScatter,
-            VictoryBrushContainer, VictoryZoomContainer
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          random, range, React, ReactDOM, VictoryChart, VictoryAxis, VictoryLine, VictoryScatter,
+          VictoryBrushContainer, VictoryZoomContainer
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/brush-and-zoom/docs.js
+++ b/src/screens/guides/components/brush-and-zoom/docs.js
@@ -7,11 +7,12 @@ import {
 import { random, range } from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class CustomComponentGuide extends React.Component {
+class BrushAndZoomGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           random, range, React, ReactDOM, VictoryChart, VictoryAxis, VictoryLine, VictoryScatter,
           VictoryBrushContainer, VictoryZoomContainer
@@ -20,3 +21,9 @@ export default class CustomComponentGuide extends React.Component {
     );
   }
 }
+
+BrushAndZoomGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default BrushAndZoomGuide;

--- a/src/screens/guides/components/custom-charts/docs.js
+++ b/src/screens/guides/components/custom-charts/docs.js
@@ -4,11 +4,12 @@ import { VictoryAxis, VictoryLine } from "victory-chart";
 import { VictoryLabel } from "victory-core";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class CustomStylesTutorial extends React.Component {
+class CustomStylesTutorial extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           React,
           ReactDOM,
@@ -20,3 +21,9 @@ export default class CustomStylesTutorial extends React.Component {
     );
   }
 }
+
+CustomStylesTutorial.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default CustomStylesTutorial;

--- a/src/screens/guides/components/custom-charts/docs.js
+++ b/src/screens/guides/components/custom-charts/docs.js
@@ -1,27 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import { VictoryAxis, VictoryLine } from "victory-chart";
 import { VictoryLabel } from "victory-core";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class CustomStylesTutorial extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            React,
-            ReactDOM,
-            VictoryAxis,
-            VictoryLine,
-            VictoryLabel
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          React,
+          ReactDOM,
+          VictoryAxis,
+          VictoryLine,
+          VictoryLabel
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/custom-components/docs.js
+++ b/src/screens/guides/components/custom-components/docs.js
@@ -1,27 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import {
   VictoryBar, VictoryScatter, VictoryAxis, VictoryLabel, VictoryGroup,
   VictoryChart, VictoryLine, VictoryPie, VictoryArea, Area
 } from "victory";
-import { ecologyPlaygroundLoading } from "formidable-landers";
 import { random, range } from "lodash";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class CustomComponentGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            random, range, React, ReactDOM, VictoryBar, VictoryScatter, VictoryLine,
-            VictoryPie, VictoryChart, VictoryAxis, VictoryGroup, VictoryLabel, VictoryArea, Area
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          random, range, React, ReactDOM, VictoryBar, VictoryScatter, VictoryLine,
+          VictoryPie, VictoryChart, VictoryAxis, VictoryGroup, VictoryLabel, VictoryArea, Area
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/custom-components/docs.js
+++ b/src/screens/guides/components/custom-components/docs.js
@@ -7,11 +7,12 @@ import {
 import { random, range } from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class CustomComponentGuide extends React.Component {
+class CustomComponentGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           random, range, React, ReactDOM, VictoryBar, VictoryScatter, VictoryLine,
           VictoryPie, VictoryChart, VictoryAxis, VictoryGroup, VictoryLabel, VictoryArea, Area
@@ -20,3 +21,9 @@ export default class CustomComponentGuide extends React.Component {
     );
   }
 }
+
+CustomComponentGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default CustomComponentGuide;

--- a/src/screens/guides/components/data-accessors/docs.js
+++ b/src/screens/guides/components/data-accessors/docs.js
@@ -1,21 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import { VictoryBar, VictoryLine, VictoryChart, VictoryAxis} from "victory";
 import { assign, range } from "lodash";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class DataAccessorsGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{ assign, range, React, ReactDOM, VictoryBar, VictoryLine, VictoryChart, VictoryAxis}}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{ assign, range, React, ReactDOM, VictoryBar, VictoryLine, VictoryChart, VictoryAxis}}
+      />
     );
   }
 }

--- a/src/screens/guides/components/data-accessors/docs.js
+++ b/src/screens/guides/components/data-accessors/docs.js
@@ -4,13 +4,20 @@ import { VictoryBar, VictoryLine, VictoryChart, VictoryAxis} from "victory";
 import { assign, range } from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class DataAccessorsGuide extends React.Component {
+class DataAccessorsGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{ assign, range, React, ReactDOM, VictoryBar, VictoryLine, VictoryChart, VictoryAxis}}
       />
     );
   }
 }
+
+DataAccessorsGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default DataAccessorsGuide;

--- a/src/screens/guides/components/ecology-recipe.js
+++ b/src/screens/guides/components/ecology-recipe.js
@@ -1,0 +1,42 @@
+import React from "react";
+import Ecology from "ecology";
+import { ecologyPlaygroundLoading } from "formidable-landers";
+
+class EcologyRecipe extends React.Component {
+  customRenderers() {
+    return {
+      heading: (text, level) => {
+        const escaped = text.toLowerCase().replace(/[^\w]+/g, "-");
+
+        return `<h${level} id="${escaped}"><a class="Anchor" href="#${escaped}" aria-hidden="true"></a>${text}</h${level}/>`;
+      },
+      ...ecologyPlaygroundLoading
+    };
+  }
+
+  render() {
+    const { scope, overview } = this.props;
+
+    return (
+      <div className="Recipe Markdown">
+        <Ecology
+          playgroundtheme="elegant"
+          overview={overview}
+          scope={scope}
+          customRenderers={this.customRenderers()}
+        />
+      </div>
+    );
+  }
+}
+
+EcologyRecipe.propTypes = {
+  scope: React.PropTypes.object.isRequired,
+  overview: React.PropTypes.string.isRequired
+};
+
+EcologyRecipe.defaultProps = {
+  children: null
+};
+
+export default EcologyRecipe;

--- a/src/screens/guides/components/ecology-recipe.js
+++ b/src/screens/guides/components/ecology-recipe.js
@@ -1,30 +1,18 @@
 import React from "react";
-import Ecology from "ecology";
+import EcologyLinkable from "../../../components/ecology-linkable";
 import { ecologyPlaygroundLoading } from "formidable-landers";
 
 class EcologyRecipe extends React.Component {
-  customRenderers(pathname) {
-    return {
-      heading: (text, level) => {
-        const escaped = text.toLowerCase().replace(/[^\w]+/g, "-");
-
-        return `<h${level} id="${escaped}"><a class="Anchor" href="${pathname}#${escaped}" aria-hidden="true"></a>${text}</h${level}/>`;
-      },
-      ...ecologyPlaygroundLoading
-    };
-  }
-
   render() {
     const { scope, overview, location } = this.props;
-    const pathname = location.pathname;
 
     return (
       <div className="Recipe Markdown">
-        <Ecology
-          playgroundtheme="elegant"
+        <EcologyLinkable
           overview={overview}
           scope={scope}
-          customRenderers={this.customRenderers(pathname)}
+          location={location}
+          customRenderers={ecologyPlaygroundLoading}
         />
       </div>
     );

--- a/src/screens/guides/components/ecology-recipe.js
+++ b/src/screens/guides/components/ecology-recipe.js
@@ -3,19 +3,20 @@ import Ecology from "ecology";
 import { ecologyPlaygroundLoading } from "formidable-landers";
 
 class EcologyRecipe extends React.Component {
-  customRenderers() {
+  customRenderers(pathname) {
     return {
       heading: (text, level) => {
         const escaped = text.toLowerCase().replace(/[^\w]+/g, "-");
 
-        return `<h${level} id="${escaped}"><a class="Anchor" href="#${escaped}" aria-hidden="true"></a>${text}</h${level}/>`;
+        return `<h${level} id="${escaped}"><a class="Anchor" href="${pathname}#${escaped}" aria-hidden="true"></a>${text}</h${level}/>`;
       },
       ...ecologyPlaygroundLoading
     };
   }
 
   render() {
-    const { scope, overview } = this.props;
+    const { scope, overview, location } = this.props;
+    const pathname = location.pathname;
 
     return (
       <div className="Recipe Markdown">
@@ -23,7 +24,7 @@ class EcologyRecipe extends React.Component {
           playgroundtheme="elegant"
           overview={overview}
           scope={scope}
-          customRenderers={this.customRenderers()}
+          customRenderers={this.customRenderers(pathname)}
         />
       </div>
     );
@@ -32,6 +33,7 @@ class EcologyRecipe extends React.Component {
 
 EcologyRecipe.propTypes = {
   scope: React.PropTypes.object.isRequired,
+  location: React.PropTypes.object.isRequired,
   overview: React.PropTypes.string.isRequired
 };
 

--- a/src/screens/guides/components/events/docs.js
+++ b/src/screens/guides/components/events/docs.js
@@ -1,27 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import {
   VictoryBar, VictoryArea, VictoryChart, VictoryPie, VictoryStack,
   VictorySharedEvents, Bar, VictoryLabel
 } from "victory";
 import { assign } from "lodash";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class EventsGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            assign, React, ReactDOM, VictoryBar, Bar, VictoryArea, VictoryLabel,
-            VictoryPie, VictoryChart, VictoryStack, VictorySharedEvents
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          assign, React, ReactDOM, VictoryBar, Bar, VictoryArea, VictoryLabel,
+          VictoryPie, VictoryChart, VictoryStack, VictorySharedEvents
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/events/docs.js
+++ b/src/screens/guides/components/events/docs.js
@@ -7,11 +7,12 @@ import {
 import { assign } from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class EventsGuide extends React.Component {
+class EventsGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           assign, React, ReactDOM, VictoryBar, Bar, VictoryArea, VictoryLabel,
           VictoryPie, VictoryChart, VictoryStack, VictorySharedEvents
@@ -20,3 +21,9 @@ export default class EventsGuide extends React.Component {
     );
   }
 }
+
+EventsGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default EventsGuide;

--- a/src/screens/guides/components/guide.js
+++ b/src/screens/guides/components/guide.js
@@ -27,7 +27,7 @@ class GuideDocs extends React.Component {
     return (
       <TitleMeta title={`${conf.text} | Victory Guides`}>
         <a href={editUrl} className="SubHeading">Edit this page</a>
-        <Docs />
+        <Docs location={this.props.location} />
       </TitleMeta>
     );
   }
@@ -41,6 +41,7 @@ class GuideDocs extends React.Component {
 }
 
 GuideDocs.propTypes = {
+  location: React.PropTypes.object.isRequired,
   active: React.PropTypes.string,
   style: React.PropTypes.object
 };

--- a/src/screens/guides/components/layout/docs.js
+++ b/src/screens/guides/components/layout/docs.js
@@ -6,11 +6,12 @@ import {
 } from "victory";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class LayoutGuide extends React.Component {
+class LayoutGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel, VictoryChart,
           VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryPortal
@@ -19,3 +20,9 @@ export default class LayoutGuide extends React.Component {
     );
   }
 }
+
+LayoutGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default LayoutGuide;

--- a/src/screens/guides/components/layout/docs.js
+++ b/src/screens/guides/components/layout/docs.js
@@ -1,26 +1,21 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import {
   VictoryPie, VictoryContainer, VictoryLabel, VictoryChart, VictoryLine, VictoryAxis,
   VictoryBar, VictoryScatter, VictoryStack, VictoryPortal
 } from "victory";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class LayoutGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel, VictoryChart,
-            VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryPortal
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel, VictoryChart,
+          VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryPortal
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/tooltips/docs.js
+++ b/src/screens/guides/components/tooltips/docs.js
@@ -1,29 +1,24 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Ecology from "ecology";
 import {
   VictoryPie, VictoryContainer, VictoryLabel, VictoryChart, VictoryLine, VictoryAxis,
   VictoryBar, VictoryScatter, VictoryStack, VictoryTooltip, VictoryVoronoiTooltip,
   VictoryGroup, VictoryVoronoiContainer
 } from "victory";
 import { range, random} from "lodash";
-import { ecologyPlaygroundLoading } from "formidable-landers";
+import EcologyRecipe from "../ecology-recipe";
 
 export default class TooltipsGuide extends React.Component {
   render() {
     return (
-      <div className="Recipe">
-        <Ecology
-          overview={require("!!raw!./ecology.md")}
-          scope={{
-            range, random, React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel,
-            VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryTooltip,
-            VictoryVoronoiTooltip, VictoryGroup, VictoryChart, VictoryVoronoiContainer
-          }}
-          playgroundtheme="elegant"
-          customRenderers={ecologyPlaygroundLoading}
-        />
-      </div>
+      <EcologyRecipe
+        overview={require("!!raw!./ecology.md")}
+        scope={{
+          range, random, React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel,
+          VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryTooltip,
+          VictoryVoronoiTooltip, VictoryGroup, VictoryChart, VictoryVoronoiContainer
+        }}
+      />
     );
   }
 }

--- a/src/screens/guides/components/tooltips/docs.js
+++ b/src/screens/guides/components/tooltips/docs.js
@@ -8,11 +8,12 @@ import {
 import { range, random} from "lodash";
 import EcologyRecipe from "../ecology-recipe";
 
-export default class TooltipsGuide extends React.Component {
+class TooltipsGuide extends React.Component {
   render() {
     return (
       <EcologyRecipe
         overview={require("!!raw!./ecology.md")}
+        location={this.props.location}
         scope={{
           range, random, React, ReactDOM, VictoryPie, VictoryContainer, VictoryLabel,
           VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryTooltip,
@@ -22,3 +23,9 @@ export default class TooltipsGuide extends React.Component {
     );
   }
 }
+
+TooltipsGuide.propTypes = {
+  location: React.PropTypes.object
+};
+
+export default TooltipsGuide;

--- a/src/screens/guides/index.js
+++ b/src/screens/guides/index.js
@@ -30,7 +30,10 @@ class Guides extends React.Component {
     return (
       <TitleMeta title="Victory | Guides">
         <Page sidebar={activeGuide}>
-          <Guide active={activeGuide} />
+          <Guide
+            active={activeGuide}
+            location={this.props.location}
+          />
         </Page>
       </TitleMeta>
     );
@@ -38,12 +41,12 @@ class Guides extends React.Component {
 }
 
 Guides.propTypes = {
+  location: React.PropTypes.object.isRequired,
   params: React.PropTypes.object
 };
 
 Guides.defaultProps = {
   params: null
 };
-
 
 export default Radium(Guides);


### PR DESCRIPTION
Pass a customer renderer to `marked` for heading tags to insert a link. Thanks to @paulathevalley for the original suggestion, which is also the [exact example](https://github.com/chjj/marked#overriding-renderer-methods) listed in their docs.

![anchorguides](https://cloud.githubusercontent.com/assets/3731165/25598879/9c2755c0-2e8c-11e7-96bf-0ff570505c8a.gif)

Created the `EcologyRecipe` component to make the guide components more DRY. Patterns followed for passing down the location object and rendering the anchor path taken from the [comparable code in the docs](https://github.com/FormidableLabs/victory-docs/blob/master/src/components/markdown.js#L56).

I will create a follow up task to convert the docs page to ecology.