### PR TITLE
Playgrounds for all Charts and Containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "react-router-scroll": "^0.4.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "victory": "0.18.0"
+    "victory": "0.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha": "^3.1.2",
     "normalize.css": "^5.0.0",
     "prismjs": "^1.5.1",
+    "prop-types": "^15.5.10",
     "radium": "^0.18.1",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 // Variables and Stylesheet
 import "../styles/styles.css";
@@ -19,8 +20,8 @@ class App extends React.Component {
 }
 
 App.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  children: React.PropTypes.node
+  location: PropTypes.object.isRequired,
+  children: PropTypes.node
 };
 
 App.defaultProps = {

--- a/src/components/ecology-linkable.js
+++ b/src/components/ecology-linkable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Ecology from "ecology";
+import PropTypes from "prop-types";
 import markdown from "../markdown";
 
 class EcologyLinkable extends React.Component {
@@ -30,10 +31,10 @@ class EcologyLinkable extends React.Component {
 }
 
 EcologyLinkable.propTypes = {
-  scope: React.PropTypes.object.isRequired,
-  location: React.PropTypes.object.isRequired,
-  overview: React.PropTypes.string.isRequired,
-  customRenderers: React.PropTypes.object.isRequired
+  scope: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  overview: PropTypes.string.isRequired,
+  customRenderers: PropTypes.object.isRequired
 };
 
 EcologyLinkable.defaultProps = {

--- a/src/components/ecology-recipe.js
+++ b/src/components/ecology-recipe.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyLinkable from "./ecology-linkable";
 import { ecologyPlaygroundLoading } from "formidable-landers";
 
@@ -20,9 +21,9 @@ class EcologyRecipe extends React.Component {
 }
 
 EcologyRecipe.propTypes = {
-  scope: React.PropTypes.object.isRequired,
-  location: React.PropTypes.object.isRequired,
-  overview: React.PropTypes.string.isRequired
+  scope: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  overview: PropTypes.string.isRequired
 };
 
 EcologyRecipe.defaultProps = {

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 // Common
 import { Footer } from "formidable-landers";
@@ -18,7 +19,7 @@ class VictoryFooter extends React.Component {
 }
 
 VictoryFooter.propTypes = {
-  home: React.PropTypes.bool
+  home: PropTypes.bool
 };
 
 VictoryFooter.defaultProps = {

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 // Common
@@ -47,7 +48,7 @@ class VictoryHeader extends React.Component {
 }
 
 VictoryHeader.propTypes = {
-  home: React.PropTypes.bool
+  home: PropTypes.bool
 };
 
 VictoryHeader.defaultProps = {

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 
 // Icons
@@ -65,7 +66,7 @@ class Icon extends React.Component {
 }
 
 Icon.propTypes = {
-  glyph: React.PropTypes.oneOf(["back", "coming-soon", "external-link", "internal-link"])
+  glyph: PropTypes.oneOf(["back", "coming-soon", "external-link", "internal-link"])
 };
 
 Icon.defaultProps = {

--- a/src/components/page.js
+++ b/src/components/page.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ScrollContainer } from "react-router-scroll";
 
 import Sidebar from "./sidebar";
@@ -46,9 +47,9 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
-  children: React.PropTypes.node,
-  location: React.PropTypes.object,
-  sidebar: React.PropTypes.string
+  children: PropTypes.node,
+  location: PropTypes.object,
+  sidebar: PropTypes.string
 };
 
 Page.defaultProps = {

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {observer, PropTypes as MobxPropTypes} from "mobx-react";
 
 import SidebarList from "./list";
@@ -27,14 +28,14 @@ class Sidebar extends React.Component {
 }
 
 Sidebar.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  store: React.PropTypes.shape({
-    searchText: React.PropTypes.string.isRequired,
-    searchIndex: React.PropTypes.array.isRequired,
+  location: PropTypes.object.isRequired,
+  store: PropTypes.shape({
+    searchText: PropTypes.string.isRequired,
+    searchIndex: PropTypes.array.isRequired,
     sidebarContent: MobxPropTypes.observableArray.isRequired,
-    sidebarMatchingNodes: React.PropTypes.object.isRequired
+    sidebarMatchingNodes: PropTypes.object.isRequired
   }).isRequired,
-  active: React.PropTypes.string
+  active: PropTypes.string
 };
 
 Sidebar.defaultProps = {

--- a/src/components/sidebar/list.js
+++ b/src/components/sidebar/list.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import {PropTypes as MobxPropTypes} from "mobx-react";
 
@@ -106,12 +107,12 @@ class SidebarList extends React.Component {
 }
 
 SidebarList.propTypes = {
-  isSearching: React.PropTypes.bool.isRequired,
-  location: React.PropTypes.object.isRequired,
+  isSearching: PropTypes.bool.isRequired,
+  location: PropTypes.object.isRequired,
   content: MobxPropTypes.observableArrayOf(
-    React.PropTypes.object
+    PropTypes.object
   ).isRequired,
-  matchingNodes: React.PropTypes.object.isRequired
+  matchingNodes: PropTypes.object.isRequired
 };
 
 export default SidebarList;

--- a/src/components/sidebar/search-input.js
+++ b/src/components/sidebar/search-input.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {observer} from "mobx-react";
 
 class SidebarSearchInput extends React.Component {
@@ -31,8 +32,8 @@ class SidebarSearchInput extends React.Component {
 }
 
 SidebarSearchInput.propTypes = {
-  store: React.PropTypes.shape({
-    searchText: React.PropTypes.string.isRequired
+  store: PropTypes.shape({
+    searchText: PropTypes.string.isRequired
   })
 };
 

--- a/src/components/sidebar/selectable-item.js
+++ b/src/components/sidebar/selectable-item.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { times } from "lodash";
 import Icon from "../icon";
@@ -127,11 +127,11 @@ class SidebarSelectableItem extends React.Component {
 }
 
 SidebarSelectableItem.propTypes = {
-  text: React.PropTypes.string.isRequired,
-  path: React.PropTypes.string.isRequired,
-  location: React.PropTypes.object.isRequired,
-  toc: React.PropTypes.array.isRequired,
-  alwaysExpand: React.PropTypes.bool
+  text: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  location: PropTypes.object.isRequired,
+  toc: PropTypes.array.isRequired,
+  alwaysExpand: PropTypes.bool
 };
 
 SidebarSelectableItem.defaultProps = {

--- a/src/components/title-meta.js
+++ b/src/components/title-meta.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import DocumentMeta from "react-document-meta";
 
 class TitleMeta extends React.Component {
@@ -21,8 +22,8 @@ class TitleMeta extends React.Component {
 }
 
 TitleMeta.propTypes = {
-  title: React.PropTypes.string,
-  children: React.PropTypes.node
+  title: PropTypes.string,
+  children: PropTypes.node
 };
 
 export default TitleMeta;

--- a/src/screens/about/components/showcase-app.js
+++ b/src/screens/about/components/showcase-app.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 class ShowcaseApp extends React.Component {
   render() {
@@ -25,13 +26,13 @@ class ShowcaseApp extends React.Component {
 }
 
 ShowcaseApp.propTypes = {
-  screenshot: React.PropTypes.shape({
-    src: React.PropTypes.string.isRequired,
-    alt: React.PropTypes.string.isRequired
+  screenshot: PropTypes.shape({
+    src: PropTypes.string.isRequired,
+    alt: PropTypes.string.isRequired
   }),
-  company: React.PropTypes.string.isRequired,
-  description: React.PropTypes.string.isRequired,
-  even: React.PropTypes.bool
+  company: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  even: PropTypes.bool
 };
 
 export default ShowcaseApp;

--- a/src/screens/docs/components/create-container/ecology.md
+++ b/src/screens/docs/components/create-container/ecology.md
@@ -2,7 +2,7 @@
 
 `createContainer` makes a container component with multiple behaviors. It allows you to effectively
 combine any two of the following containers: `VictoryBrushContainer`,
-`VictorySelectionContainer`, `VictoryVoronoiContainer`, or `VictoryZoomContainer`.
+`VictoryCursorContainer`, `VictorySelectionContainer`, `VictoryVoronoiContainer`, or `VictoryZoomContainer`.
 
 ```js
 const VictoryZoomVoronoiContainer = createContainer("zoom", "voronoi");
@@ -18,7 +18,8 @@ createContainer(behaviorA, behaviorB)
 
 ### behavior
 
-Each `behavior` must be one of the following strings: `"brush"`, `"selection"`, `"voronoi"`, and `"zoom"`.
+Each `behavior` must be one of the following strings:
+`"brush"`, `"cursor"`, `"selection"`, `"voronoi"`, and `"zoom"`.
 The resulting container uses the events from both behaviors.
 For example, if both behaviors use the click event (like zoom and selection) the combined container
 will trigger both behaviors' events on each click.
@@ -33,23 +34,20 @@ The following example creates a custom container that combines `VictoryVoronoiCo
 `VictoryZoomContainer`. Hovering over the chart will use Voronoi to highlight data points,
 while scrolling and dragging will zoom and pan.
 
-```jsx
-import React from "react";
-import {
-  createContainer,
-  VictoryChart,
-  VictoryScatter
-} from "victory";
-
+```playground_norender
 const VictoryZoomVoronoiContainer = createContainer("zoom", "voronoi");
+const data = range(100).map((x) => ({x, y: 100 + x + random(10)}));
 
 const App = () => (
-  <div>
-    <VictoryChart
-      containerComponent={<VictoryZoomVoronoiContainer labels={(d) => `y: ${d.y}`} />}
-    >
-      <VictoryScatter />
-    </VictoryChart>
-  </div>
+  <VictoryChart
+    containerComponent={
+      <VictoryZoomVoronoiContainer
+        labels={(d) => `${d.x}, ${d.y}`}
+      />
+    }>
+    <VictoryScatter data={data} />
+  </VictoryChart>
 );
+
+ReactDOM.render(<App/>, mountNode);
 ```

--- a/src/screens/docs/components/create-container/index.js
+++ b/src/screens/docs/components/create-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { range, round, random } from "lodash";
 import * as Victory from "victory";
@@ -23,7 +24,7 @@ class CreateContainer extends React.Component {
 }
 
 CreateContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default CreateContainer;

--- a/src/screens/docs/components/create-container/index.js
+++ b/src/screens/docs/components/create-container/index.js
@@ -1,4 +1,7 @@
 import React from "react";
+import ReactDOM from "react-dom";
+import { range, round, random } from "lodash";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +16,7 @@ class CreateContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React, ReactDOM, range, round, random }}
       />
     );
   }

--- a/src/screens/docs/components/native/index.js
+++ b/src/screens/docs/components/native/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class Native extends React.Component {
 }
 
 Native.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default Native;

--- a/src/screens/docs/components/victory-animation/index.js
+++ b/src/screens/docs/components/victory-animation/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryAnimation extends React.Component {
 }
 
 VictoryAnimation.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryAnimation;

--- a/src/screens/docs/components/victory-area/ecology.md
+++ b/src/screens/docs/components/victory-area/ecology.md
@@ -2,22 +2,32 @@
 
 VictoryArea renders a dataset as a single area. VictoryArea can be composed with [VictoryChart] to create area charts.
 
+```playground
+<VictoryArea
+  data={[
+    {month: "September", profit: 35000, loss: 2000},
+    {month: "October", profit: 44000, loss: 8000},
+    {month: "November", profit: 55000, loss: 5000}
+  ]}
+  x="month"
+  y={(datum) => datum.profit - datum.loss}
+/>
+```
+
 ## Props
 
 ### data
 
 Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [`x` and `y`] data accessor props to define a custom data format. The `data` prop must be given as an array.
 
-```jsx
-<VictoryArea
+*example:*
+
+```js
   data={[
     {month: "September", profit: 35000, loss: 2000},
     {month: "October", profit: 42000, loss: 8000},
     {month: "November", profit: 55000, loss: 5000}
   ]}
-  x="month"
-  y={(datum) => datum.profit - datum.loss}
-/>
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-area/index.js
+++ b/src/screens/docs/components/victory-area/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryArea extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-area/index.js
+++ b/src/screens/docs/components/victory-area/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryArea extends React.Component {
 }
 
 VictoryArea.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryArea;

--- a/src/screens/docs/components/victory-axis/ecology.md
+++ b/src/screens/docs/components/victory-axis/ecology.md
@@ -2,6 +2,10 @@
 
 VictoryAxis renders a single axis which can be used on its own or composed with [VictoryChart].
 
+```playground
+<VictoryAxis tickValues={["apples", "bananas", "oranges"]}/>
+```
+
 ## Props
 
 ### tickValues

--- a/src/screens/docs/components/victory-axis/ecology.md
+++ b/src/screens/docs/components/victory-axis/ecology.md
@@ -3,7 +3,7 @@
 VictoryAxis renders a single axis which can be used on its own or composed with [VictoryChart].
 
 ```playground
-<VictoryAxis tickValues={["apples", "bananas", "oranges"]}/>
+<VictoryAxis tickValues={[1, 2, 4, 8]}/>
 ```
 
 ## Props

--- a/src/screens/docs/components/victory-axis/index.js
+++ b/src/screens/docs/components/victory-axis/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryAxis extends React.Component {
 }
 
 VictoryAxis.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryAxis;

--- a/src/screens/docs/components/victory-axis/index.js
+++ b/src/screens/docs/components/victory-axis/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryAxis extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-bar/ecology.md
+++ b/src/screens/docs/components/victory-bar/ecology.md
@@ -2,13 +2,7 @@
 
 VictoryBar renders a dataset as series of bars. VictoryBar can be composed with [VictoryChart] to create bar charts.
 
-## Props
-
-### data
-
-Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` keys. Use the [`x` and `y`] data accessor props to define a custom data format. The `data` prop must be given as an array.
-
-```jsx
+```playground
 <VictoryBar
   data={[
     {month: "September", profit: 35000, loss: 2000},
@@ -18,6 +12,22 @@ Specify data via the `data` prop. By default, Victory components expect data as 
   x="month"
   y={(datum) => datum.profit - datum.loss}
 />
+```
+
+## Props
+
+### data
+
+Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` keys. Use the [`x` and `y`] data accessor props to define a custom data format. The `data` prop must be given as an array.
+
+*example:*
+
+```js
+  data={[
+    {month: "September", profit: 35000, loss: 2000},
+    {month: "October", profit: 42000, loss: 8000},
+    {month: "November", profit: 55000, loss: 5000}
+  ]}
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-bar/index.js
+++ b/src/screens/docs/components/victory-bar/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryBar extends React.Component {
 }
 
 VictoryBar.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryBar;

--- a/src/screens/docs/components/victory-bar/index.js
+++ b/src/screens/docs/components/victory-bar/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryBar extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-brush-container/ecology.md
+++ b/src/screens/docs/components/victory-brush-container/ecology.md
@@ -18,10 +18,13 @@ system, and should be added as the `containerComponent` of the top-level compone
 However, the component that uses it must be standalone
 (`standalone={true}`), which is the default for all top-level Victory components.
 
-```jsx
-<VictoryChart containerComponent={<VictoryBrushContainer/>}>
-  <VictoryLine data={data} />
-  <VictoryBar data={moreData}/>
+```playground
+<VictoryChart
+  containerComponent={
+    <VictoryBrushContainer dimension="x" selectedDomain={{x: [0.1, 0.3]}}/>
+  }
+>
+  <VictoryLine />
 </VictoryChart>
 ```
 

--- a/src/screens/docs/components/victory-brush-container/index.js
+++ b/src/screens/docs/components/victory-brush-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryBrushContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-brush-container/index.js
+++ b/src/screens/docs/components/victory-brush-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryBrushContainer extends React.Component {
 }
 
 VictoryBrushContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryBrushContainer;

--- a/src/screens/docs/components/victory-candlestick/ecology.md
+++ b/src/screens/docs/components/victory-candlestick/ecology.md
@@ -8,7 +8,7 @@ VictoryCandlestick renders a dataset as a series of candlesticks. VictoryCandles
 
 Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` keys. Use the [`open`, `close`, `high` and `low`] data accessor props to define a custom data format. The `data` prop must be given as an array.
 
-```jsx
+```playground
 <VictoryCandlestick
   data={[
     {x: new Date(2016, 6, 1), open: 5, close: 10, high: 15, low: 0},

--- a/src/screens/docs/components/victory-candlestick/index.js
+++ b/src/screens/docs/components/victory-candlestick/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryCandlestick extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-candlestick/index.js
+++ b/src/screens/docs/components/victory-candlestick/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryCandlestick extends React.Component {
 }
 
 VictoryCandlestick.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryCandlestick;

--- a/src/screens/docs/components/victory-chart/ecology.md
+++ b/src/screens/docs/components/victory-chart/ecology.md
@@ -6,6 +6,12 @@ If no children are provided, `VictoryChart` will render a set of empty default a
 `VictoryChart` works with:
 [VictoryArea], [VictoryAxis], [VictoryBar], [VictoryCandlestick], [VictoryErrorBar], [VictoryGroup], [VictoryLine], [VictoryScatter], [VictoryStack], [VictoryVoronoi], and [VictoryVoronoiTooltip].
 
+```playground
+<VictoryChart>
+  <VictoryScatter/>
+</VictoryChart>
+```
+
 ## Props
 
 ### children

--- a/src/screens/docs/components/victory-chart/index.js
+++ b/src/screens/docs/components/victory-chart/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryChart extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-chart/index.js
+++ b/src/screens/docs/components/victory-chart/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryChart extends React.Component {
 }
 
 VictoryChart.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryChart;

--- a/src/screens/docs/components/victory-clip-container/index.js
+++ b/src/screens/docs/components/victory-clip-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryClipContainer extends React.Component {
 }
 
 VictoryClipContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryClipContainer;

--- a/src/screens/docs/components/victory-container/index.js
+++ b/src/screens/docs/components/victory-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryContainer extends React.Component {
 }
 
 VictoryContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryContainer;

--- a/src/screens/docs/components/victory-cursor-container/ecology.md
+++ b/src/screens/docs/components/victory-cursor-container/ecology.md
@@ -13,11 +13,12 @@ However, the component that uses it must be standalone
 Note that the cursor allows you to inspect the entire domain, not just the data points.
 If you would like to instead highlight only the data points, consider using [VictoryVoronoiContainer].
 
-```jsx
+```playground
 <VictoryScatter
-  data={data}
   containerComponent={
-    <VictoryCursorContainer cursorLabel={d => d.y}/>
+    <VictoryCursorContainer
+      cursorLabel={(d) => `${round(d.x, 2)}, ${round(d.y, 2)}`}
+    />
   }
 />
 ```

--- a/src/screens/docs/components/victory-cursor-container/index.js
+++ b/src/screens/docs/components/victory-cursor-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { round } from "lodash";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
@@ -23,7 +24,7 @@ class VictoryBrushContainer extends React.Component {
 }
 
 VictoryBrushContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryBrushContainer;

--- a/src/screens/docs/components/victory-cursor-container/index.js
+++ b/src/screens/docs/components/victory-cursor-container/index.js
@@ -1,6 +1,9 @@
 import React from "react";
+import { round } from "lodash";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
+
 const overview = require("!!raw!./ecology.md");
 
 class VictoryBrushContainer extends React.Component {
@@ -13,7 +16,7 @@ class VictoryBrushContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React, round }}
       />
     );
   }

--- a/src/screens/docs/components/victory-errorbar/ecology.md
+++ b/src/screens/docs/components/victory-errorbar/ecology.md
@@ -2,21 +2,31 @@
 
 VictoryErrorBar renders a dataset as a series of error bars. VictoryErrorBar can be composed with other components to add x and y error bars to data.
 
+```playground
+<VictoryErrorBar
+  data={[
+    {x: 15, y: 35000, error: 0.2},
+    {x: 20, y: 42000, error: 0.05},
+    {x: 30, y: 30000, error: 0.1}
+  ]}
+  errorX={(datum) => datum.error * datum.x}
+  errorY={(datum) => datum.error * datum.y}
+/>
+```
+
 ## Props
 
 ### data
 
 Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
 
+*example:*
 ```jsx
-<VictoryErrorBar
-  data={[
-    {x: 15, y: 35000, error: 0.2},
-    {x: 20, y: 42000, error: 0.05},
-    {x: 30, y: 55000, error: 0.1}
-  ]}
-  errorX={(datum) => datum.error * datum.x}
-  errorY={(datum) => datum.error * datum.y}
+data={[
+  {x: 15, y: 35000},
+  {x: 20, y: 42000},
+  {x: 30, y: 30000}
+]}
 />
 ```
 

--- a/src/screens/docs/components/victory-errorbar/index.js
+++ b/src/screens/docs/components/victory-errorbar/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryErrorbar extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-errorbar/index.js
+++ b/src/screens/docs/components/victory-errorbar/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryErrorbar extends React.Component {
 }
 
 VictoryErrorbar.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryErrorbar;

--- a/src/screens/docs/components/victory-group/ecology.md
+++ b/src/screens/docs/components/victory-group/ecology.md
@@ -5,6 +5,13 @@
 `VictoryGroup` works with:
 [VictoryArea], [VictoryBar], [VictoryCandlestick], [VictoryErrorBar], [VictoryLine], [VictoryScatter], [VictoryStack], [VictoryVoronoi], and [VictoryVoronoiTooltip].
 
+```playground
+<VictoryGroup data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}]}>
+  <VictoryBar/>
+  <VictoryLine/>
+</VictoryGroup>
+```
+
 ## Props
 
 ### children
@@ -15,16 +22,14 @@
 
 When `data` is provided for `VictoryGroup` it will be passed to every child in the group. Use this as a convenience in cases where all components should have identical data, for example, adding data points to a line, or adding voronoi tooltips to data. Omit this prop when child components should not share data. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
 
-```jsx
-<VictoryGroup
+*example:*
+
+```js
   data={[
     {month: "September", profit: 35000, loss: 2000},
     {month: "October", profit: 42000, loss: 8000},
     {month: "November", profit: 55000, loss: 5000}
   ]}
-  x="month"
-  y={(datum) => datum.profit - datum.loss}
-/>
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-group/index.js
+++ b/src/screens/docs/components/victory-group/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryGroup extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-group/index.js
+++ b/src/screens/docs/components/victory-group/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryGroup extends React.Component {
 }
 
 VictoryGroup.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryGroup;

--- a/src/screens/docs/components/victory-label/index.js
+++ b/src/screens/docs/components/victory-label/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryLabel extends React.Component {
 }
 
 VictoryLabel.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryLabel;

--- a/src/screens/docs/components/victory-legend/ecology.md
+++ b/src/screens/docs/components/victory-legend/ecology.md
@@ -2,6 +2,16 @@
 
 `VictoryLegend` renders a chart legend component.
 
+```playground
+<VictoryLegend
+  data={[
+    {name: 'A', symbol: { type: 'circle'}},
+    {name: 'B', symbol: { type: 'square'}},
+    {name: 'C', symbol: { type: 'star'}}
+    ]}
+/>
+```
+
 ## Props
 
 ### colorScale

--- a/src/screens/docs/components/victory-legend/index.js
+++ b/src/screens/docs/components/victory-legend/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryLegend extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-legend/index.js
+++ b/src/screens/docs/components/victory-legend/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryLegend extends React.Component {
 }
 
 VictoryLegend.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryLegend;

--- a/src/screens/docs/components/victory-line/ecology.md
+++ b/src/screens/docs/components/victory-line/ecology.md
@@ -2,13 +2,7 @@
 
 VictoryLine renders a dataset as a single line. VictoryLine can be composed with [VictoryChart] to create line charts.
 
-## Props
-
-### data
-
-Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
-
-```jsx
+```playground
 <VictoryLine
   data={[
     {month: "September", profit: 35000, loss: 2000},
@@ -18,6 +12,22 @@ Specify data via the `data` prop. By default, Victory components expect data as 
   x="month"
   y={(datum) => datum.profit - datum.loss}
 />
+```
+
+## Props
+
+### data
+
+Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
+
+*example:*
+
+```js
+data={[
+  {month: "September", profit: 35000, loss: 2000},
+  {month: "October", profit: 42000, loss: 8000},
+  {month: "November", profit: 55000, loss: 5000}
+]}
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-line/index.js
+++ b/src/screens/docs/components/victory-line/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryLine extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-line/index.js
+++ b/src/screens/docs/components/victory-line/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryLine extends React.Component {
 }
 
 VictoryLine.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryLine;

--- a/src/screens/docs/components/victory-pie/ecology.md
+++ b/src/screens/docs/components/victory-pie/ecology.md
@@ -2,22 +2,32 @@
 
 `VictoryPie` renders a dataset as a pie chart.
 
+```playground
+<VictoryPie
+  data={[
+    {month: "Sep", profit: 35000, loss: 2000},
+    {month: "Oct", profit: 42000, loss: 8000},
+    {month: "Nov", profit: 55000, loss: 5000}
+  ]}
+  x="month"
+  y={(datum) => datum.profit - datum.loss}
+/>
+```
+
 ## Props
 
 ### data
 
 Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
 
-```jsx
-<VictoryPie
-  data={[
-    {month: "September", profit: 35000, loss: 2000},
-    {month: "October", profit: 42000, loss: 8000},
-    {month: "November", profit: 55000, loss: 5000}
-  ]}
-  x="month"
-  y={(datum) => datum.profit - datum.loss}
-/>
+*example:*
+
+```js
+data={[
+  {month: "September", profit: 35000, loss: 2000},
+  {month: "October", profit: 42000, loss: 8000},
+  {month: "November", profit: 55000, loss: 5000}
+]}
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-pie/index.js
+++ b/src/screens/docs/components/victory-pie/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryPie extends React.Component {
 }
 
 VictoryPie.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryPie;

--- a/src/screens/docs/components/victory-pie/index.js
+++ b/src/screens/docs/components/victory-pie/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryPie extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-portal/index.js
+++ b/src/screens/docs/components/victory-portal/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryPortal extends React.Component {
 }
 
 VictoryPortal.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryPortal;

--- a/src/screens/docs/components/victory-primitives/index.js
+++ b/src/screens/docs/components/victory-primitives/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryPrimitives extends React.Component {
 }
 
 VictoryPrimitives.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryPrimitives;

--- a/src/screens/docs/components/victory-scatter/ecology.md
+++ b/src/screens/docs/components/victory-scatter/ecology.md
@@ -2,13 +2,7 @@
 
 VictoryScatter renders a dataset as a series of points. VictoryScatter can be composed with [VictoryChart] to create scatter plots.
 
-## Props
-
-### data
-
-Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
-
-```jsx
+```playground
 <VictoryScatter
   data={[
     {month: "September", profit: 35000, loss: 2000},
@@ -18,6 +12,22 @@ Specify data via the `data` prop. By default, Victory components expect data as 
   x="month"
   y={(datum) => datum.profit - datum.loss}
 />
+```
+
+## Props
+
+### data
+
+Specify data via the `data` prop. By default, Victory components expect data as an array of objects with `x` and `y` properties. Use the [x and y] data accessor props to define a custom data format. The `data` prop must be given as an array.
+
+*example:*
+
+```js
+  data={[
+    {month: "September", profit: 35000, loss: 2000},
+    {month: "October", profit: 42000, loss: 8000},
+    {month: "November", profit: 55000, loss: 5000}
+  ]}
 ```
 
 ### x and y

--- a/src/screens/docs/components/victory-scatter/index.js
+++ b/src/screens/docs/components/victory-scatter/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryScatter extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-scatter/index.js
+++ b/src/screens/docs/components/victory-scatter/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryScatter extends React.Component {
 }
 
 VictoryScatter.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryScatter;

--- a/src/screens/docs/components/victory-selection-container/ecology.md
+++ b/src/screens/docs/components/victory-selection-container/ecology.md
@@ -16,10 +16,11 @@ system, and should be added as the `containerComponent` of the top-level compone
 However, the component that uses it must be standalone
 (`standalone={true}`), which is the default for all top-level Victory components.
 
-```jsx
+```playground
 <VictoryChart containerComponent={<VictorySelectionContainer/>}>
-  <VictoryLine data={data} />
-  <VictoryBar data={moreData}/>
+  <VictoryScatter
+    style={{ data: { fill: (d, active) => active ? "tomato" : "gray" } }}
+  />
 </VictoryChart>
 ```
 

--- a/src/screens/docs/components/victory-selection-container/index.js
+++ b/src/screens/docs/components/victory-selection-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictorySelectionContainer extends React.Component {
 }
 
 VictorySelectionContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictorySelectionContainer;

--- a/src/screens/docs/components/victory-selection-container/index.js
+++ b/src/screens/docs/components/victory-selection-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictorySelectionContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-shared-events/index.js
+++ b/src/screens/docs/components/victory-shared-events/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictorySharedEvents extends React.Component {
 }
 
 VictorySharedEvents.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictorySharedEvents;

--- a/src/screens/docs/components/victory-stack/ecology.md
+++ b/src/screens/docs/components/victory-stack/ecology.md
@@ -5,6 +5,20 @@
 `VictoryStack` works with:
 [VictoryArea], [VictoryBar], [VictoryCandlestick], [VictoryErrorBar], [VictoryGroup],[VictoryLine], and [VictoryScatter]
 
+```playground
+<VictoryStack>
+  <VictoryArea
+    data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}]}
+  />
+  <VictoryArea
+    data={[{x: "a", y: 1}, {x: "b", y: 4}, {x: "c", y: 5}]}
+  />
+  <VictoryArea
+    data={[{x: "a", y: 3}, {x: "b", y: 2}, {x: "c", y: 6}]}
+  />
+</VictoryStack>
+```
+
 ## Props
 
 ### children
@@ -122,7 +136,7 @@ The `animate` prop specifies props for [VictoryAnimation] and [VictoryTransition
 
 ### events
 
-`VictoryStack` uses the `VictorySharedEvents` wrapper to coordinate events between its children. The `events` prop takes an array of event objects. Event objects are composed of a `target`, an `eventKey`, a `childName` and `eventHandlers`. Targets may be any valid style namespace for a given component, so "data" and "labels" are valid targets for this components like `VictoryBar`. `eventKey` may be given as a single value, or as an array of values to specify individual targets. If `eventKey` is not specified, the given `eventHandlers` will be attached to all elements of the specified `target` type. The `childName` property may be given as a string or an array of strings to target multiple children. The `eventHandlers` object should be given as an object whose keys are standard event names (i.e. `onClick`) and whose values are event callbacks. The return value of an event handler is used to modify elemnts. The return value should be given as an object or an array of objects with optional `target`, `childName` and `eventKey` keys for specifying the element(s) to be modified, and a `mutation` key whose value is a function. The `target` and `eventKey` keys will default to those corresponding to the element the event handler was attached to. The `mutation` function will be called with the calculated props for each element that should be modified (i.e. a bar label), and the object returned from the mutation function will override the props of that element via object assignment.
+`VictoryStack` uses the `VictorySharedEvents` wrapper to coordinate events between its children. The `events` prop takes an array of event objects. Event objects are composed of a `target`, an `eventKey`, a `childName` and `eventHandlers`. Targets may be any valid style namespace for a given component, so "data" and "labels" are valid targets for this components like `VictoryBar`. `eventKey` may be given as a single value, or as an array of values to specify individual targets. If `eventKey` is not specified, the given `eventHandlers` will be attached to all elements of the specified `target` type. The `childName` property may be given as a string or an array of strings to target multiple children. The `eventHandlers` object should be given as an object whose keys are standard event names (i.e. `onClick`) and whose values are event callbacks. The return value of an event handler is used to modify elements. The return value should be given as an object or an array of objects with optional `target`, `childName` and `eventKey` keys for specifying the element(s) to be modified, and a `mutation` key whose value is a function. The `target` and `eventKey` keys will default to those corresponding to the element the event handler was attached to. The `mutation` function will be called with the calculated props for each element that should be modified (i.e. a bar label), and the object returned from the mutation function will override the props of that element via object assignment.
 
 *examples:*
 ```jsx

--- a/src/screens/docs/components/victory-stack/index.js
+++ b/src/screens/docs/components/victory-stack/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryStack extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-stack/index.js
+++ b/src/screens/docs/components/victory-stack/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryStack extends React.Component {
 }
 
 VictoryStack.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryStack;

--- a/src/screens/docs/components/victory-theme/index.js
+++ b/src/screens/docs/components/victory-theme/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryTheme extends React.Component {
 }
 
 VictoryTheme.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryTheme;

--- a/src/screens/docs/components/victory-tooltip/index.js
+++ b/src/screens/docs/components/victory-tooltip/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryTooltip extends React.Component {
 }
 
 VictoryTooltip.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryTooltip;

--- a/src/screens/docs/components/victory-transition/index.js
+++ b/src/screens/docs/components/victory-transition/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryTransition extends React.Component {
 }
 
 VictoryTransition.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryTransition;

--- a/src/screens/docs/components/victory-voronoi-container/ecology.md
+++ b/src/screens/docs/components/victory-voronoi-container/ecology.md
@@ -13,10 +13,17 @@ system, and should be added as the `containerComponent` of the top-level compone
 However, the component that uses it must be standalone
 (`standalone={true}`), which is the default for all top-level Victory components.
 
-```jsx
-<VictoryChart containerComponent={<VictoryVoronoiContainer/>}>
-  <VictoryLine data={data} />
-  <VictoryBar data={moreData}/>
+```playground
+<VictoryChart
+  containerComponent={
+    <VictoryVoronoiContainer
+      labels={(d) => `${round(d.x, 2)}, ${round(d.y, 2)}`}
+    />
+  }
+>
+  <VictoryScatter
+    y={(datum) => Math.sin(2 * Math.PI * datum.x)}
+  />
 </VictoryChart>
 ```
 

--- a/src/screens/docs/components/victory-voronoi-container/index.js
+++ b/src/screens/docs/components/victory-voronoi-container/index.js
@@ -1,4 +1,6 @@
 import React from "react";
+import * as Victory from "victory";
+import { round } from "lodash";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +15,7 @@ class VictoryVoronoiContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React, round }}
       />
     );
   }

--- a/src/screens/docs/components/victory-voronoi-container/index.js
+++ b/src/screens/docs/components/victory-voronoi-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import { round } from "lodash";
 import EcologyRecipe from "../../../../components/ecology-recipe";
@@ -22,7 +23,7 @@ class VictoryVoronoiContainer extends React.Component {
 }
 
 VictoryVoronoiContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryVoronoiContainer;

--- a/src/screens/docs/components/victory-voronoi-tooltip/index.js
+++ b/src/screens/docs/components/victory-voronoi-tooltip/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryVoronoiTooltip extends React.Component {
 }
 
 VictoryVoronoiTooltip.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryVoronoiTooltip;

--- a/src/screens/docs/components/victory-voronoi/index.js
+++ b/src/screens/docs/components/victory-voronoi/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryVoronoi extends React.Component {
 }
 
 VictoryVoronoi.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryVoronoi;

--- a/src/screens/docs/components/victory-zoom-container/ecology.md
+++ b/src/screens/docs/components/victory-zoom-container/ecology.md
@@ -9,10 +9,17 @@ system, and should be added as the `containerComponent` of the top-level compone
 However, the component that uses it must be standalone
 (`standalone={true}`), which is the default for all top-level Victory components.
 
-```jsx
-<VictoryChart containerComponent={<VictoryZoomContainer/>}>
-  <VictoryLine data={data} />
-  <VictoryBar data={moreData}/>
+```playground
+<VictoryChart
+  containerComponent={
+    <VictoryZoomContainer
+      labels={(d) => `${round(d.x, 2)}, ${round(d.y, 2)}`}
+    />
+  }
+>
+  <VictoryScatter
+    y={(datum) => Math.sin(2 * Math.PI * datum.x)}
+  />
 </VictoryChart>
 ```
 

--- a/src/screens/docs/components/victory-zoom-container/index.js
+++ b/src/screens/docs/components/victory-zoom-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -13,7 +14,7 @@ class VictoryZoomContainer extends React.Component {
       <EcologyRecipe
         overview={overview}
         location={this.props.location}
-        scope={{}}
+        scope={{ ...Victory, React }}
       />
     );
   }

--- a/src/screens/docs/components/victory-zoom-container/index.js
+++ b/src/screens/docs/components/victory-zoom-container/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import * as Victory from "victory";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
@@ -21,7 +22,7 @@ class VictoryZoomContainer extends React.Component {
 }
 
 VictoryZoomContainer.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryZoomContainer;

--- a/src/screens/docs/components/victory-zoom/index.js
+++ b/src/screens/docs/components/victory-zoom/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EcologyRecipe from "../../../../components/ecology-recipe";
 import markdown from "../../../../markdown";
 const overview = require("!!raw!./ecology.md");
@@ -20,7 +21,7 @@ class VictoryZoom extends React.Component {
 }
 
 VictoryZoom.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default VictoryZoom;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { VictoryBar, VictoryChart, VictoryAxis, VictoryTheme, VictoryStack } from "victory";
 import Radium from "radium";
@@ -73,8 +74,8 @@ class Docs extends React.Component {
 }
 
 Docs.propTypes = {
-  location: React.PropTypes.object,
-  params: React.PropTypes.object
+  location: PropTypes.object,
+  params: PropTypes.object
 };
 
 Docs.defaultProps = {

--- a/src/screens/gallery/components/preview.js
+++ b/src/screens/gallery/components/preview.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { render } from "react-dom";
 import ReactDOMServer from "react-dom/server";
 import { transform } from "babel-standalone";
@@ -22,7 +23,7 @@ class Preview extends Component {
     const { codeText, context, noRender, scope } = this.props;
     const generateContextTypes = (c) => {
       return `{ ${Object.keys(c).map((val) =>
-        `${val}: React.PropTypes.any.isRequired`).join(", ")} }`;
+        `${val}: PropTypes.any.isRequired`).join(", ")} }`;
     };
 
     if (noRender) {

--- a/src/screens/gallery/examples/animating-circular-progress-bar.example.js
+++ b/src/screens/gallery/examples/animating-circular-progress-bar.example.js
@@ -12,13 +12,15 @@ class App extends React.Component {
   constructor() {
     super();
     this.state = {
-      percent: 0, data: this.getData(0)
+      percent: 25, data: this.getData(0)
     };
   }
 
   componentDidMount() {
+    let percent = 25;
     this.setStateInterval = window.setInterval(() => {
-      const percent = Math.random() * 100;
+      percent += (Math.random() * 25);
+      percent = (percent > 100) ? 0 : percent;
       this.setState({
         percent, data: this.getData(percent)
       });

--- a/src/screens/gallery/examples/custom-tooltip-labels.example.js
+++ b/src/screens/gallery/examples/custom-tooltip-labels.example.js
@@ -2,14 +2,14 @@
   all one-line star comments starting with "eslint", "global", or "NOTE"
   will be removed before displaying this document to the user
 */
-/* global React, ReactDOM, App, mountNode */
+/* global React, ReactDOM, App, mountNode, PropTypes */
 /* global VictoryPie, VictoryLabel, VictoryTooltip  */
 
 // Victory requires `react@^15.5.0` and `prop-types@^15.5.0`
 
 class CustomLabel extends React.Component {
   static defaultEvents = VictoryTooltip.defaultEvents;
-  static propTypes = {text: React.PropTypes.string};
+  static propTypes = {text: PropTypes.string};
 
   render() {
     return (

--- a/src/screens/gallery/index.js
+++ b/src/screens/gallery/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import Radium from "radium";
 import Playground from "component-playground";
@@ -44,6 +45,7 @@ class Gallery extends React.Component {
     this.scope = {
       React,
       ReactDOM,
+      PropTypes,
       Area,
       Bar,
       VictoryAnimation,
@@ -159,8 +161,8 @@ class Gallery extends React.Component {
 }
 
 Gallery.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  params: React.PropTypes.object
+  location: PropTypes.object.isRequired,
+  params: PropTypes.object
 };
 
 Gallery.defaultProps = {

--- a/src/screens/gallery/index.js
+++ b/src/screens/gallery/index.js
@@ -80,17 +80,17 @@ class Gallery extends React.Component {
     const previews = config.map((example, index) => {
       return (
         <div key={index} className="Gallery-item">
-          <Preview
-            codeText={this.processCodeText(example.code)}
-            noRender={false}
-            theme="elegant"
-            scope={this.scope}
-          />
-          <p className="Gallery-item-heading">
-            <Link to={`/gallery/${example.slug}`}>
-              {example.text}&nbsp;<Icon glyph="internal-link" />
-            </Link>
-          </p>
+          <Link to={`/gallery/${example.slug}`}>
+            <Preview
+              codeText={this.processCodeText(example.code)}
+              noRender={false}
+              theme="elegant"
+              scope={this.scope}
+            />
+            <p className="Gallery-item-heading">
+                {example.text}&nbsp;<Icon glyph="internal-link" />
+            </p>
+          </Link>
         </div>
       );
     });

--- a/src/screens/guides/components/animations/docs.js
+++ b/src/screens/guides/components/animations/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import { VictoryBar, VictoryScatter, VictoryChart } from "victory";
 import { range, random } from "lodash";
 import EcologyRecipe from "../../../../components/ecology-recipe";
@@ -23,7 +24,7 @@ class AnimationGuide extends React.Component {
 }
 
 AnimationGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default AnimationGuide;

--- a/src/screens/guides/components/brush-and-zoom/docs.js
+++ b/src/screens/guides/components/brush-and-zoom/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import {
   VictoryAxis, VictoryChart, VictoryLine, VictoryScatter,
   VictoryBrushContainer, VictoryZoomContainer
@@ -29,7 +30,7 @@ class BrushAndZoomGuide extends React.Component {
 }
 
 BrushAndZoomGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default BrushAndZoomGuide;

--- a/src/screens/guides/components/custom-charts/docs.js
+++ b/src/screens/guides/components/custom-charts/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import { VictoryAxis, VictoryLine } from "victory-chart";
 import { VictoryLabel } from "victory-core";
 import EcologyRecipe from "../../../../components/ecology-recipe";
@@ -29,7 +30,7 @@ class CustomStylesTutorial extends React.Component {
 }
 
 CustomStylesTutorial.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default CustomStylesTutorial;

--- a/src/screens/guides/components/custom-components/docs.js
+++ b/src/screens/guides/components/custom-components/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import {
   VictoryBar, VictoryScatter, VictoryAxis, VictoryLabel, VictoryGroup,
   VictoryChart, VictoryLine, VictoryPie, VictoryArea, Area
@@ -29,7 +30,7 @@ class CustomComponentGuide extends React.Component {
 }
 
 CustomComponentGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default CustomComponentGuide;

--- a/src/screens/guides/components/custom-components/ecology.md
+++ b/src/screens/guides/components/custom-components/ecology.md
@@ -104,12 +104,6 @@ Other Victory components may even be used in creating custom components, as in t
 
 ```playground_norender
 class CustomPie extends React.Component {
-  static propTypes = {
-    datum: React.PropTypes.object,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
-  };
-
   render() {
     const {datum, x, y} = this.props;
     const pieWidth = 120;

--- a/src/screens/guides/components/data-accessors/docs.js
+++ b/src/screens/guides/components/data-accessors/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import { VictoryBar, VictoryLine, VictoryChart, VictoryAxis} from "victory";
 import { assign, range } from "lodash";
 import EcologyRecipe from "../../../../components/ecology-recipe";
@@ -23,7 +24,7 @@ class DataAccessorsGuide extends React.Component {
 }
 
 DataAccessorsGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default DataAccessorsGuide;

--- a/src/screens/guides/components/events/docs.js
+++ b/src/screens/guides/components/events/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import {
   VictoryBar, VictoryArea, VictoryChart, VictoryPie, VictoryStack,
   VictorySharedEvents, Bar, VictoryLabel
@@ -29,7 +30,7 @@ class EventsGuide extends React.Component {
 }
 
 EventsGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default EventsGuide;

--- a/src/screens/guides/components/guide.js
+++ b/src/screens/guides/components/guide.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 import TitleMeta from "../../../components/title-meta";
 import find from "lodash/find";
@@ -43,9 +44,9 @@ class GuideDocs extends React.Component {
 }
 
 GuideDocs.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  active: React.PropTypes.string,
-  style: React.PropTypes.object
+  location: PropTypes.object.isRequired,
+  active: PropTypes.string,
+  style: PropTypes.object
 };
 
 GuideDocs.defaultProps = {

--- a/src/screens/guides/components/layout/docs.js
+++ b/src/screens/guides/components/layout/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import {
   VictoryPie, VictoryContainer, VictoryLabel, VictoryChart, VictoryLine, VictoryAxis,
   VictoryBar, VictoryScatter, VictoryStack, VictoryPortal
@@ -28,7 +29,7 @@ class LayoutGuide extends React.Component {
 }
 
 LayoutGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default LayoutGuide;

--- a/src/screens/guides/components/theme-park/demo-component.js
+++ b/src/screens/guides/components/theme-park/demo-component.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { times } from "lodash";
 import {
   VictoryChart, VictoryScatter, VictoryPie, VictoryLine, VictoryStack, VictoryBar, VictoryAxis
@@ -93,7 +94,7 @@ const DemoComponent = ({ theme }) => {
 };
 
 DemoComponent.propTypes = {
-  theme: React.PropTypes.object
+  theme: PropTypes.object
 };
 
 export default DemoComponent;

--- a/src/screens/guides/components/theme-park/pure-render.js
+++ b/src/screens/guides/components/theme-park/pure-render.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 export default class PureRender extends React.Component {
   shouldComponentUpdate(nextProps) {
@@ -22,5 +23,5 @@ export default class PureRender extends React.Component {
 }
 
 PureRender.propTypes = {
-  children: React.PropTypes.any
+  children: PropTypes.any
 };

--- a/src/screens/guides/components/tooltips/docs.js
+++ b/src/screens/guides/components/tooltips/docs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import {
   VictoryPie, VictoryContainer, VictoryLabel, VictoryChart, VictoryLine, VictoryAxis,
   VictoryBar, VictoryScatter, VictoryStack, VictoryTooltip, VictoryVoronoiTooltip,
@@ -31,7 +32,7 @@ class TooltipsGuide extends React.Component {
 }
 
 TooltipsGuide.propTypes = {
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 export default TooltipsGuide;

--- a/src/screens/guides/index.js
+++ b/src/screens/guides/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 import Prism from "prismjs";
 /* eslint-disable no-unused-vars */
@@ -44,8 +45,8 @@ class Guides extends React.Component {
 }
 
 Guides.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  params: React.PropTypes.object
+  location: PropTypes.object.isRequired,
+  params: PropTypes.object
 };
 
 Guides.defaultProps = {

--- a/src/screens/home/components/benefits.js
+++ b/src/screens/home/components/benefits.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 // Common
@@ -125,7 +126,7 @@ class Benefits extends React.Component {
 }
 
 Benefits.propTypes = {
-  style: React.PropTypes.object
+  style: PropTypes.object
 };
 
 Benefits.defaultProps = {

--- a/src/screens/home/components/companies.js
+++ b/src/screens/home/components/companies.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 // Common
@@ -33,7 +34,7 @@ class Companies extends React.Component {
 }
 
 Companies.propTypes = {
-  style: React.PropTypes.object
+  style: PropTypes.object
 };
 
 Companies.defaultProps = {

--- a/src/screens/home/components/hero-demo.js
+++ b/src/screens/home/components/hero-demo.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 
 // VComponents
@@ -105,7 +106,7 @@ class Native extends React.Component {
 }
 
 Native.propTypes = {
-  alt: React.PropTypes.bool
+  alt: PropTypes.bool
 };
 
 export default Radium(Native); // eslint-disable-line new-cap


### PR DESCRIPTION
Adds playgrounds to all of the chart types and containers. In almost all the cases here, the playground placed right after the initial description, to give the reader an idea of what the component does (and whether or not they are interested in it!). We can use this as a base to build on; I am sure there are other places we'll want playgrounds, and ways in which we can make these playground examples more illustrative. 