### PR TITLE
Fix documentation links on VictoryStack page

### DIFF
--- a/src/screens/docs/components/victory-stack/ecology.md
+++ b/src/screens/docs/components/victory-stack/ecology.md
@@ -191,16 +191,17 @@ The `sharedEvents` prop is used to coordinate events between Victory components 
 
 The `name` prop is used to reference a component instance when defining shared events.
 
-[VictoryArea]: https://formidable.com/open-source/docs/victory-area
-[VictoryAxis]: https://formidable.com/open-source/docs/victory-axis
-[VictoryBar]: https://formidable.com/open-source/docs/victory-bar
-[VictoryCandlestick]: https://formidable.com/open-source/docs/victory-candlestick
-[VictoryErrorBar]: https://formidable.com/open-source/docs/victory-error-bar
-[VictoryGroup]: https://formidable.com/open-source/docs/victory-group
-[VictoryLine]: https://formidable.com/open-source/docs/victory-line
-[VictoryScatter]: https://formidable.com/open-source/docs/victory-scatter
-[VictoryVoronoi]: https://formidable.com/open-source/docs/victory-voronoi
-[VictoryVoronoiTooltip]: https://formidable.com/open-source/docs/victory-voronoi-tooltip
+[VictoryArea]: https://formidable.com/open-source/victory/docs/victory-area
+[VictoryAxis]: https://formidable.com/open-source/victory/docs/victory-axis
+[VictoryBar]: https://formidable.com/open-source/victory/docs/victory-bar
+[VictoryCandlestick]: https://formidable.com/open-source/victory/docs/victory-candlestick
+[VictoryErrorBar]: https://formidable.com/open-source/victory/docs/victory-error-bar
+[VictoryGroup]: https://formidable.com/open-source/victory/docs/victory-group
+[VictoryLine]: https://formidable.com/open-source/victory/docs/victory-line
+[VictoryScatter]: https://formidable.com/open-source/victory/docs/victory-scatter
+[VictoryStack]: https://formidable.com/open-source/victory/docs/victory-stack
+[VictoryVoronoi]: https://formidable.com/open-source/victory/docs/victory-voronoi
+[VictoryVoronoiTooltip]: https://formidable.com/open-source/victory/docs/victory-voronoi-tooltip
 [grayscale theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/grayscale.js
 [Read more about themes here]: https://formidable.com/open-source/victory/guides/themes
 [width and height]: https://formidable.com/open-source/victory/docs/victory-stack#width-and-height


### PR DESCRIPTION
#### What does this PR do?
This PR simply fixes the links referenced on the [VictoryStack](http://formidable.com/open-source/victory/docs/victory-stack/) page that were going to 404's due to an outdated link.

Example 404 - https://formidable.com/open-source/docs/victory-candlestick
