### PR TITLE
Revamp Victory Native Tutorial 

### DIFF
--- a/src/screens/docs/components/native/ecology.md
+++ b/src/screens/docs/components/native/ecology.md
@@ -1,109 +1,152 @@
 # Getting Started with Victory Native
 
-Victory Native extends Victory for use on iOS and Android. Victory Native uses an identical API, so Victory code can easily be reused across platforms. The following guide replicates our [getting started guide] with iOS, but an Android demo is also included. For more advanced Victory examples, check out our [other guides].
+Victory Native extends Victory for use on iOS and Android. Victory Native uses an identical API, so Victory code can easily be reused across platforms. The following guide replicates our [getting started guide] with React Native. For more advanced Victory examples, check out our [other guides].
 
 ## Overview
 
 If you're already comfortable with Victory and React Native, this tutorial will not be necessary. The only changes you will need to make to existing Victory code work in a React Native app are:
 
-- install `victory-native` and `react-native-svg`
-- import components from `victory-native` instead of `victory`
-- replace web specific events with native specific events _e.g.,_ `onMouseOver` -> `onPressIn`
+- Install `victory-native` and `react-native-svg`. Please note the `react-native-svg` [version restrictions].
+- Link `react-native-svg`.
+- Import components from `victory-native` instead of `victory`.
+- Replace web-specific events with native-specific events, _e.g._ `onMouseOver` -> `onPressIn`.
 
 ## Tutorial
 
-In this guide, we’ll show you how to get started with Victory and walk you through the creation and customization of a composed chart. We’ve created a GitHub repository with the completed project, and will link to the corresponding commit where appropriate to help you follow along. If you want, you can [view the completed tutorial here].
+In this guide, we’ll show you how to get started with Victory Native and walk you through the creation and customization of a composed chart.
+
+### Prerequisites
+
+This project builds off of the [React Native Getting Started Guide].
+If you don't have `create-react-native-app` or have forget how to use it, simply follow that guide.
 
 ### 1. Set up a basic React Native project
 
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/16d3ce02be0fe75426a1a67b6aaf8f46f72760b7)
+Use `create-react-native-app` to create a new React Native project.
 
-You can start from scratch, or start with the first commit of this tutorial:
-
-```
-  $ git clone https://github.com/FormidableLabs/victory-native-tutorial.git
-  $ cd victory-native-tutorial
-  $ git reset --hard 16d3ce
+```sh
+create-react-native-app VictoryNativeTutorial
+cd VictoryNativeTutorial/
 ```
 
 Your project structure should look like this:
 
-```
-  .
+```sh
+  VictoryNativeTutorial
   ├── .gitignore
-  ├── .npmignore
-  ├── package.json             # package.json will be modified
+  ├── package.json
+  ├── App.js # we will modify this file
+  ├── App.test.js
   ├── README.md
-  └── demo
-      ├── android
-      │   └── ...
-      ├── ios
-      │   └── ...
-      ├── ...
-      ├── index.android.js
-      ├── index.ios.js          # index.ios.js will be modified
-      └── package.json
+  ├── app.json
+  └── node_modules/
 ```
+
+You can try out the project using `npm start` as you had in the [React Native Getting Started Guide].
+If you are having problems with Expo, just refer back to that guide.
+You can also use `npm run ios` (if you have XCode installed) or `npm run android` (if you have an Android emulator installed).
 
 ### 2. Add Victory Native
 
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/4f93425ef7aa62dfa8bb8d6a40e39f574affdeed)
-To use Victory Native, add `victory-native` and `react-native-svg` to your project dependencies in `package.json`, and `npm install` all dependencies.
+To use Victory Native, add `victory-native` to your project.
+
+```sh
+npm install victory-native --save
+# or
+yarn add victory-native
+```
+
+_Note:_ You may receive "unmet peer dependency" errors after installing;
+rest assured that Victory Native can be used with `create-react-native-app`.
+
+If you look in your `package.json`, you should now have `victory-native` in your dependencies:
 
 ```js
   ...
   "dependencies": {
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
-    "react-native": "~0.35.0",
-    "react-native-svg": "^4.3.0",
-    "victory-native": "~0.4.0"
+    "expo": "...",
+    "react": "...",
+    "react-native": "...",
+    "victory-native": "..."
   }
 ```
 
-To see your base project, first run `npm start` and open `demo/ios/Demo.xcodeproj` in xcode, then run the app. If this is your first time working with React Native, you may need to [install additional dependencies].
+_Note:_ `victory-native` also relies on `react-native-svg` (see the [Overview](#overview) above),
+but this is already included in `expo`, which `create-react-native-app` uses.
 
-Once you're up and running, you can import your first Victory Native component in `demo/index.ios.js`.
+Once you're up and running, you can import your first Victory Native component in `App.js`.
 
-```
+```jsx
 import { VictoryBar } from "victory-native";
 ```
 
-and render it inside your `ScrollView`:
+and render it inside your `View`:
 
 ```jsx
+export default class App extends React.Component {
   render() {
     return (
-      <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.text}>{"Victory Tutorial"}</Text>
+      <View style={styles.container}>
         <VictoryBar/>
-      </ScrollView>
+      </View>
     );
   }
+}
 ```
 
-Just like Victory, Victory Native components will use default data when no props are provided. Press `⌘ + R` in the simulator to refresh the app and see your changes.
+Just like Victory, Victory Native components will use default data when no props are provided.
+Save your changes to `App.js` and your app will be refreshed automatically.
 
 ### 3. Add Data and Styles
-
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/3f259ec52c9e71b01c14ff6d4375950179578da8)
 
 Now let's add some data. Take advantage of [data accessors] to specify how an array of data should be plotted. We can change the color of the bars with a basic style object.
 
 ```jsx
-  ...
-  const data = [
-    {quarter: 1, earnings: 13000},
-    {quarter: 2, earnings: 16500},
-    {quarter: 3, earnings: 14250},
-    {quarter: 4, earnings: 19000}
-  ];
+...
+const data = [
+  {quarter: 1, earnings: 13000},
+  {quarter: 2, earnings: 16500},
+  {quarter: 3, earnings: 14250},
+  {quarter: 4, earnings: 19000}
+];
 
-  class Demo extends Component {
-    render() {
-      return (
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.text}>{"Victory Tutorial"}</Text>
+export default class App extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.text}>{"Victory Tutorial"}</Text>
+        <VictoryBar
+          style={{
+            data: {fill: "blue"}
+          }}
+          data={data}
+          x="quarter"
+          y="earnings"
+        />
+      </View>
+    );
+  }
+}
+```
+
+### 4. Add VictoryChart
+
+Add the [VictoryChart wrapper] to add default axes to your bar component. VictoryChart also reconciles the domain, scale, and other props of its children so that they form an accurate chart. First import `VictoryChart`:
+
+```jsx
+import { VictoryBar, VictoryChart } from "victory-native";
+```
+
+Then wrap `VictoryBar` in `VictoryChart`. Save the file to see the default axes.
+
+```jsx
+...
+export default class App extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.text}>{"Victory Tutorial"}</Text>
+        <VictoryChart>
           <VictoryBar
             style={{
               data: {fill: "blue"}
@@ -112,43 +155,14 @@ Now let's add some data. Take advantage of [data accessors] to specify how an ar
             x="quarter"
             y="earnings"
           />
-        </ScrollView>
-      );
-    }
+        </VictoryChart>
+      </View>
+    );
   }
-```
-
-### 4. Add VictoryChart
-
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/a016e8eafc954f90a2974273cbb3c75d1e427048)
-
-Add the [VictoryChart wrapper] to add default axes to your bar component. VictoryChart also reconciles the domain, scale, and other props of its children so that they form an accurate chart. First import `VictoryChart`
-
-```jsx
-import { VictoryBar, VictoryChart } from "victory-native";
-```
-Then wrap `VictoryBar` in `VictoryChart`. Refresh your app to see the default axes.
-
-```jsx
-  ...
-  <ScrollView contentContainerStyle={styles.container}>
-    <Text style={styles.text}>{"Victory Tutorial"}</Text>
-    <VictoryChart>
-      <VictoryBar
-        style={{
-          data: {fill: "blue"}
-        }}
-        data={data}
-        x="quarter"
-        y="earnings"
-      />
-    </VictoryChart>
-  </ScrollView>
+}
 ```
 
 ### 5. Customize the Axes
-
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/5f3bffa364a919db7648d4ba5446e6d4df557c29)
 
 Import `VictoryAxis` to define your own axis components for `VictoryChart` to use:
 
@@ -159,66 +173,63 @@ Import `VictoryAxis` to define your own axis components for `VictoryChart` to us
 Set the `dependentAxis` prop to specify the dependent axis. [`tickValues`] and [`tickFormat`] define the position and display of the axis ticks. `VictoryChart` automatically calculates a domain based on the data of its children. To add some space between the bars and the axes, specify a `domainPadding` prop. This prop will increase the domain by a value corresponding to the specified number of pixels. [Read more about `domainPadding`].
 
 ```jsx
-  <VictoryChart
-    domainPadding={40}
-  >
-    <VictoryAxis
-      tickValues={[1, 2, 3, 4]}
-      tickFormat={["Quarter 1", "Quarter 2", "Quarter 3", "Quarter 4"]}
-    />
-    <VictoryAxis
-      dependentAxis
-      tickFormat={(x) => (`$${x / 1000}k`)}
-    />
-    <VictoryBar
-      style={{
-        data: {fill: "blue"}
-      }}
-      data={data}
-      x="quarter"
-      y="earnings"
-    />
-  </VictoryChart>
+<VictoryChart
+  domainPadding={40}
+>
+  <VictoryAxis
+    tickValues={[1, 2, 3, 4]}
+    tickFormat={["Quarter 1", "Quarter 2", "Quarter 3", "Quarter 4"]}
+  />
+  <VictoryAxis
+    dependentAxis
+    tickFormat={(x) => (`$${x / 1000}k`)}
+  />
+  <VictoryBar
+    style={{
+      data: {fill: "blue"}
+    }}
+    data={data}
+    x="quarter"
+    y="earnings"
+  />
+</VictoryChart>
 ```
 
 ### 6. Stack data and change the theme
 
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/ba2de02ca866b6ca1517e11d2b4e75b6ecd309ef)
-
-Import `VictoryStack` and `VictoryTheme`
+Now import `VictoryStack` and `VictoryTheme`:
 
 ```jsx
-  import {
-    VictoryAxis, VictoryBar, VictoryChart, VictoryStack, VictoryTheme
-  } from "victory-native";
-
+import {
+  VictoryAxis, VictoryBar, VictoryChart, VictoryStack, VictoryTheme
+} from "victory-native";
 ```
 
-[`VictoryStack`] is a wrapper component that is used to create a stacked layout for its children. Let's add more data and create a stacked bar chart:
+[`VictoryStack`] is a wrapper component that is used to create a stacked layout for its children. Let's add more data and create a stacked bar chart.
 
 ```jsx
-  const data2012 = [
+const data1992 = [
   {quarter: 1, earnings: 13000},
   {quarter: 2, earnings: 16500},
   {quarter: 3, earnings: 14250},
   {quarter: 4, earnings: 19000}
 ];
 
-const data2013 = [
+const data1993 = [
   {quarter: 1, earnings: 15000},
   {quarter: 2, earnings: 12500},
   {quarter: 3, earnings: 19500},
   {quarter: 4, earnings: 13000}
 ];
 
-const data2014 = [
+const data1994 = [
   {quarter: 1, earnings: 11500},
   {quarter: 2, earnings: 13250},
   {quarter: 3, earnings: 20000},
   {quarter: 4, earnings: 15500}
 ];
 
-const data2015 = [
+const data1995 = [
   {quarter: 1, earnings: 18000},
   {quarter: 2, earnings: 13250},
   {quarter: 3, earnings: 15000},
@@ -226,7 +237,7 @@ const data2015 = [
 ];
 ```
 
-To define a stacked layout, just wrap `VictoryStack` around all the data components that should be stacked. `VictoryStack` can also be used within `VictoryChart`. The domain automatically adjusts to accomodate the cumulative maximum of the stacked data.
+To define a stacked layout, just wrap `VictoryStack` around all the data components that should be stacked. `VictoryStack` can also be used within `VictoryChart`. The domain automatically adjusts to accommodate the cumulative maximum of the stacked data.
 
 ```jsx
   <VictoryChart
@@ -243,22 +254,22 @@ To define a stacked layout, just wrap `VictoryStack` around all the data compone
     />
     <VictoryStack>
       <VictoryBar
-        data={data2012}
+        data={data1992}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2013}
+        data={data1993}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2014}
+        data={data1994}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2015}
+        data={data1995}
         x="quarter"
         y="earnings"
       />
@@ -266,14 +277,12 @@ To define a stacked layout, just wrap `VictoryStack` around all the data compone
   </VictoryChart>
 ```
 
-In this commit, we've also changed the theme on `VictoryChart`. Themes may be used to define a consistent look for a set of components. By default, Victory components use the [grayscale theme]. Let's see what the [material theme] looks like. [Read more about defining your own themes].
+In this step, we've also changed the theme on `VictoryChart`. Themes may be used to define a consistent look for a set of components. By default, Victory components use the [grayscale theme]. Let's see what the [material theme] looks like. [Read more about defining your own themes].
 
-*note:* Themes should be defined on the top level component.
+_Note:_ Themes should be defined on the top-level component.
 
 
 ### 7. Refine styles
-
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/0bbdda0f1594a58a7113a46063eb92746ef8d946)
 
 `VictoryStack` can also be used to control the styles of its children, but styles applied directly to a child component will always take precedence.
 
@@ -300,22 +309,22 @@ In this commit, we've also changed the theme on `VictoryChart`. Themes may be us
         style={{
           data: { width: 13, strokeWidth: 0, fill: "navy"}
         }}
-        data={data2012}
+        data={data1992}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2013}
+        data={data1993}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2014}
+        data={data1994}
         x="quarter"
         y="earnings"
       />
       <VictoryBar
-        data={data2015}
+        data={data1995}
         x="quarter"
         y="earnings"
       />
@@ -325,19 +334,17 @@ In this commit, we've also changed the theme on `VictoryChart`. Themes may be us
 
 ### 8. Replace VictoryBar with VictoryArea
 
-#### [see the commit](https://github.com/FormidableLabs/victory-native-tutorial/commit/a656196e5a0cf721d7748c0722693a0fa93d48f8)
-
-Want to see what your data looks like in a different format? Victory Native components are modular, and easily interchangeable. Let's make a stacked area chart instead of a stacked bar chart:
+Want to see what your data looks like in a different format? Victory Native components are modular, and easily interchangeable. Let's make a stacked area chart instead of a stacked bar chart.
 
 Import `VictoryArea`
 
 ```jsx
-  import {
-    VictoryAxis, VictoryArea, VictoryChart, VictoryStack, VictoryTheme }
-  from "victory-native";
+import {
+  VictoryAxis, VictoryArea, VictoryChart, VictoryStack, VictoryTheme }
+from "victory-native";
 ```
 
-Then, simply replace all instances of `VictoryBar` with `VictoryArea`, and tweak styles as necessary
+Then simply replace all instances of `VictoryBar` with `VictoryArea`, and tweak styles as necessary.
 
 ```jsx
   <VictoryChart
@@ -361,22 +368,22 @@ Then, simply replace all instances of `VictoryBar` with `VictoryArea`, and tweak
         style={{
           data: { fill: "navy" }
         }}
-        data={data2012}
+        data={data1992}
         x="quarter"
         y="earnings"
       />
       <VictoryArea
-        data={data2013}
+        data={data1993}
         x="quarter"
         y="earnings"
       />
       <VictoryArea
-        data={data2014}
+        data={data1994}
         x="quarter"
         y="earnings"
       />
       <VictoryArea
-        data={data2015}
+        data={data1995}
         x="quarter"
         y="earnings"
       />
@@ -397,3 +404,5 @@ Then, simply replace all instances of `VictoryBar` with `VictoryArea`, and tweak
 [grayscale theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/grayscale.js
 [material theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/material.js
 [Read more about defining your own themes]: https://formidable.com/open-source/victory/guides/themes
+[version restrictions]: https://github.com/react-native-community/react-native-svg#notice
+[React Native Getting Started Guide]: https://facebook.github.io/react-native/docs/getting-started.html


### PR DESCRIPTION
rewrite Victory Native Tutorial with a few goals:
- make it version-agnostic (victory, victory-native, react-native, etc.)
- mention react-native-svg version requirements
- use official React Native getting started as a basis, so we can defer RN set-up expertise to them
- obviate `victory-native-tutorial` repo, so we don't have to keep it up-to-date with versions.

Addresses https://github.com/FormidableLabs/victory-native/issues/109