### PR TITLE
interpolation example

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "react-router-scroll": "^0.4.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "victory": "0.20.0"
+    "victory": "^0.21.0"
   }
 }

--- a/src/components/config-gallery.js
+++ b/src/components/config-gallery.js
@@ -32,6 +32,10 @@ export const configGallery = [
     slug: "horizontal-grouped-bars",
     code: require("!!raw!../screens/gallery/examples/horizontal-grouped-bars.example.js")
   }, {
+    text: "Interpolation",
+    slug: "interpolation",
+    code: require("!!raw!../screens/gallery/examples/interpolation.example.js")
+  }, {
     text: "Multiaxis Line Chart with Tooltip",
     slug: "multiaxis-line-chart",
     code: require("!!raw!../screens/gallery/examples/multiaxis-line-chart.example.js")
@@ -89,5 +93,3 @@ export const configGallery = [
     code: require("!!raw!../screens/gallery/examples/voronoi-tooltips-grouped.example.js")
   }
 ];
-
-

--- a/src/screens/gallery/examples/interpolation.example.js
+++ b/src/screens/gallery/examples/interpolation.example.js
@@ -1,0 +1,90 @@
+/* NOTE
+  all one-line star comments starting with "eslint", "global", or "NOTE"
+  will be removed before displaying this document to the user
+*/
+/* global React, ReactDOM, App, mountNode */
+/* global VictoryChart, VictoryLine, VictoryChart, VictoryScatter */
+
+// Victory requires `react@^15.5.0` and `prop-types@^15.5.0`
+
+const data = [
+  {x: 0, y: 0},
+  {x: 1, y: 2},
+  {x: 2, y: 1},
+  {x: 3, y: 4},
+  {x: 4, y: 3},
+  {x: 5, y: 5}
+];
+
+const cartesianInterpolations = [
+  "basis",
+  "bundle",
+  "cardinal",
+  "catmullRom",
+  "linear",
+  "monotoneX",
+  "monotoneY",
+  "natural",
+  "step",
+  "stepAfter",
+  "stepBefore"
+];
+
+const polarInterpolations = [
+  "basis",
+  "cardinal",
+  "catmullRom",
+  "linear"
+];
+
+const InterpolationSelect = ({ currentValue, values, onChange }) => (
+  <select onChange={onChange} value={currentValue} style={{ width: 110 }}>
+    {values.map(
+      (value) => <option value={value} key={value}>{value}</option>
+    )}
+  </select>
+);
+
+class App extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      interpolation: "linear",
+      polar: false
+    };
+  }
+  render() {
+    return (
+      <div>
+        <InterpolationSelect
+          currentValue={this.state.interpolation}
+          values={this.state.polar ? polarInterpolations : cartesianInterpolations }
+          onChange={(event) => this.setState({ interpolation: event.target.value })}
+        />
+        <input
+          type="checkbox"
+          id="polar"
+          value={this.state.polar}
+          onChange={
+            (event) => this.setState({
+              polar: event.target.checked,
+              interpolation: "linear"
+            })
+          }
+          style={{ marginLeft: 50, marginRight: 5}}
+        />
+        <label htmlFor="polar">polar</label>
+        <VictoryChart polar={this.state.polar}>
+          <VictoryLine
+            interpolation={this.state.interpolation} data={data}
+          />
+          <VictoryScatter data={data}
+            style={{data: {fill: "#222"}}}
+          />
+        </VictoryChart>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App/>, mountNode);

--- a/src/screens/gallery/examples/stream-graph.example.js
+++ b/src/screens/gallery/examples/stream-graph.example.js
@@ -20,28 +20,26 @@ class GradientArea extends Area {
   }
 
   // This method exists in Area, and is completely overridden for the custom component.
-  renderArea(paths, style, events) {
+  renderArea(path, style, events) {
     const gradientId = `gradient-${Math.random()}`;
     const areaStyle = Object.assign(
       {}, style, {fill: `url(${location.href}#${gradientId})`}
     );
     const percent = `${this.props.percent}%`;
     const gray = this.toGrayscale(style.fill);
-    return paths.map((path, index) => {
-      return (
-        <g key={index}>
-          <defs>
-            <linearGradient id={gradientId}>
-                <stop offset="0%" stopColor={style.fill}/>
-                <stop offset={percent} stopColor={style.fill}/>
-                <stop offset={percent} stopColor={gray}/>
-                <stop offset="100%" stopColor={gray}/>
-            </linearGradient>
-          </defs>
-          <path key="area" style={areaStyle} d={path} {...events}/>
-        </g>
-      );
-    });
+    return (
+      <g>
+        <defs>
+          <linearGradient id={gradientId}>
+              <stop offset="0%" stopColor={style.fill}/>
+              <stop offset={percent} stopColor={style.fill}/>
+              <stop offset={percent} stopColor={gray}/>
+              <stop offset="100%" stopColor={gray}/>
+          </linearGradient>
+        </defs>
+        <path key="area" style={areaStyle} d={path} {...events}/>
+      </g>
+    );
   }
 }
 

--- a/src/screens/guides/components/custom-components/ecology.md
+++ b/src/screens/guides/components/custom-components/ecology.md
@@ -209,28 +209,26 @@ class GradientArea extends Area {
   }
 
   // This method exists in Area, and is completely overridden for the custom component.
-  renderArea(paths, style, events) {
+  renderArea(path, style, events) {
     const gradientId = `gradient-${Math.random()}`;
     const areaStyle = Object.assign(
       {}, style, {fill: `url(${location.href}#${gradientId})`}
     );
     const percent = `${this.props.percent}%`;
     const gray = this.toGrayscale(style.fill)
-    return paths.map((path, index) => {
-      return (
-        <g key={index}>
-          <defs>
-            <linearGradient id={gradientId}>
-                <stop offset="0%" stopColor={style.fill}/>
-                <stop offset={percent} stopColor={style.fill}/>
-                <stop offset={percent} stopColor={gray}/>
-                <stop offset="100%" stopColor={gray}/>
-            </linearGradient>
-          </defs>
-          <path key="area" style={areaStyle} d={path} {...events}/>
-        </g>
-      );
-    });
+    return (
+      <g>
+        <defs>
+          <linearGradient id={gradientId}>
+              <stop offset="0%" stopColor={style.fill}/>
+              <stop offset={percent} stopColor={style.fill}/>
+              <stop offset={percent} stopColor={gray}/>
+              <stop offset="100%" stopColor={gray}/>
+          </linearGradient>
+        </defs>
+        <path key="area" style={areaStyle} d={path} {...events}/>
+      </g>
+    );
   }
 }
 

--- a/src/screens/home/components/demo-custom-components.js
+++ b/src/screens/home/components/demo-custom-components.js
@@ -15,7 +15,7 @@ class GradientArea extends Area {
   }
 
   // This method exists in Area, and is completely overridden for the custom component.
-  renderArea(paths, style, events) {
+  renderArea(path, style, events) {
     const gradientId = `gradient-${Math.random()}`;
 
     const isBrowser = typeof window !== "undefined" && window.__STATIC_GENERATOR !== true;
@@ -26,21 +26,19 @@ class GradientArea extends Area {
     );
     const percent = `${this.props.percent}%`;
     const gray = this.toGrayscale(style.fill);
-    return paths.map((path, index) => {
-      return (
-        <g key={index}>
-          <defs>
-            <linearGradient id={gradientId}>
-                <stop offset="0%" stopColor={style.fill}/>
-                <stop offset={percent} stopColor={style.fill}/>
-                <stop offset={percent} stopColor={gray}/>
-                <stop offset="100%" stopColor={gray}/>
-            </linearGradient>
-          </defs>
-          <path key="area" style={areaStyle} d={path} {...events}/>
-        </g>
-      );
-    });
+    return (
+      <g>
+        <defs>
+          <linearGradient id={gradientId}>
+              <stop offset="0%" stopColor={style.fill}/>
+              <stop offset={percent} stopColor={style.fill}/>
+              <stop offset={percent} stopColor={gray}/>
+              <stop offset="100%" stopColor={gray}/>
+          </linearGradient>
+        </defs>
+        <path key="area" style={areaStyle} d={path} {...events}/>
+      </g>
+    );
   }
 }
 

--- a/static-routes.js
+++ b/static-routes.js
@@ -45,6 +45,7 @@ module.exports = [
   "/gallery/column-chart",
   "/gallery/continuously-animating-line",
   "/gallery/custom-tooltip-labels",
+  "/gallery/interpolation",
   "/gallery/horizontal-grouped-bars",
   "/gallery/multiaxis-line-chart",
   "/gallery/multipoint-tooltip-labels",


### PR DESCRIPTION
Every time I want to use interpolation, I end up wanting to play around with the different options. Why not give users a simple way to play with the various options? Also, with the new polar charts, demoing is even more important, as the [d3 docs](https://github.com/d3/d3-shape#curves) only show cartesian examples.

![jun-23-2017 15-44-05 - interpolation-example](https://user-images.githubusercontent.com/2822048/27485288-74bf8344-582c-11e7-9e51-41adb6fcd601.gif)

Question: should this be in the *Gallery* or the *Guides*? I chose Gallery, as it doesn't seem important enough for the Guides.