### PR TITLE
remove labels from VictoryZoomContainer example

### DIFF
--- a/src/screens/docs/components/victory-zoom-container/ecology.md
+++ b/src/screens/docs/components/victory-zoom-container/ecology.md
@@ -12,9 +12,7 @@ However, the component that uses it must be standalone
 ```playground
 <VictoryChart
   containerComponent={
-    <VictoryZoomContainer
-      labels={(d) => `${round(d.x, 2)}, ${round(d.y, 2)}`}
-    />
+    <VictoryZoomContainer/>
   }
 >
   <VictoryScatter


### PR DESCRIPTION
Labels aren't used in VictoryZoomContainer, so including the props in the example is probably a bad idea :) 