### PR TITLE
Fix minor syntax error in `animate` JSX code examples

### DIFF
--- a/src/screens/docs/components/victory-area/ecology.md
+++ b/src/screens/docs/components/victory-area/ecology.md
@@ -25,7 +25,7 @@ See the [Animations Guide] for more detail on animations and transitions
   animate={{
     duration: 2000,
     onLoad: { duration: 1000 }
-  )}
+  }}
 ```
 
 ### categories

--- a/src/screens/docs/components/victory-bar/ecology.md
+++ b/src/screens/docs/components/victory-bar/ecology.md
@@ -26,7 +26,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 
 ### categories

--- a/src/screens/docs/components/victory-candlestick/ecology.md
+++ b/src/screens/docs/components/victory-candlestick/ecology.md
@@ -29,7 +29,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 
 ### candleColors

--- a/src/screens/docs/components/victory-chart/ecology.md
+++ b/src/screens/docs/components/victory-chart/ecology.md
@@ -15,7 +15,7 @@
     theme={VictoryTheme.material}
   >
     <VictoryArea data={sampleData}/>
-  	<VictoryPolarAxis/>
+    <VictoryPolarAxis/>
   </VictoryChart>
 </div>
 ```
@@ -34,7 +34,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 
 ### children

--- a/src/screens/docs/components/victory-errorbar/ecology.md
+++ b/src/screens/docs/components/victory-errorbar/ecology.md
@@ -33,7 +33,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 
 ### borderWidth
@@ -391,8 +391,3 @@ x={(datum) => new Date(datum.day)}
 [`errorX`]: https://formidable.com/open-source/victory/docs/victory-candlestick#errorX
 [`errorY`]: https://formidable.com/open-source/victory/docs/victory-candlestick#errorY
 [grayscale theme]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-theme/grayscale.js
-
-
-
-
-

--- a/src/screens/docs/components/victory-group/ecology.md
+++ b/src/screens/docs/components/victory-group/ecology.md
@@ -37,7 +37,7 @@ See the [Animations Guide] for more detail on animations and transitions
   animate={{
     duration: 2000,
     onLoad: { duration: 1000 }
-  )}
+  }}
 ```
 
 ### categories

--- a/src/screens/docs/components/victory-line/ecology.md
+++ b/src/screens/docs/components/victory-line/ecology.md
@@ -34,7 +34,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 
 ### categories

--- a/src/screens/docs/components/victory-pie/ecology.md
+++ b/src/screens/docs/components/victory-pie/ecology.md
@@ -23,7 +23,7 @@ See the [Animations Guide] for more detail on animations and transitions
 ```jsx
 animate={{
   duration: 2000
-)}
+}}
 ```
 
 ### categories

--- a/src/screens/docs/components/victory-polar-axis/ecology.md
+++ b/src/screens/docs/components/victory-polar-axis/ecology.md
@@ -32,7 +32,7 @@ See the [Animations Guide] for more detail on animations
 animate={{
   duration: 2000,
   easing: "bounce"
-)}
+}}
 ```
 ### axisAngle
 
@@ -306,7 +306,7 @@ scale={{x: "time"}}
     standalone={false}
   />
   <VictoryPolarAxis dependentAxis
-  	axisAngle={45}
+    axisAngle={45}
     labelPlacement="vertical"
     theme={VictoryTheme.material}
     standalone={false}

--- a/src/screens/docs/components/victory-scatter/ecology.md
+++ b/src/screens/docs/components/victory-scatter/ecology.md
@@ -33,7 +33,7 @@ See the [Animations Guide] for more detail on animations and transitions
 animate={{
   duration: 2000,
   onLoad: { duration: 1000 }
-)}
+}}
 ```
 ### bubbleProperty
 


### PR DESCRIPTION
This PR builds off of https://github.com/FormidableLabs/victory-docs/pull/393 where there is a minor syntax error in the `animate` examples.  It fixes the examples to have the proper bracket formatting.