### PR TITLE
Centers tooltip inside the VictoryPie

### DIFF
--- a/src/screens/gallery/examples/custom-tooltip-labels.example.js
+++ b/src/screens/gallery/examples/custom-tooltip-labels.example.js
@@ -15,7 +15,7 @@ class CustomLabel extends React.Component {
         <VictoryLabel {...this.props}/>
         <VictoryTooltip
           {...this.props}
-          x={0} y={50}
+          x={200} y={250}
           text={`# ${this.props.text}`}
           orientation="top"
           pointerLength={0}


### PR DESCRIPTION
Not sure how this is rendering for anyone else, but it has been placing the tooltip up in the top-left corner. These values should center it within the VictoryPie.