### PR TITLE
Add FAQ page with list of questions

### DIFF
--- a/src/components/config-gallery.js
+++ b/src/components/config-gallery.js
@@ -72,16 +72,20 @@ export const configGallery = [
     slug: "victory-pie-center-label",
     code: require("!!raw!../screens/gallery/examples/victory-pie-center-label.example.js")
   }, {
-    text: "Voronoi Tooltips with Grouped Components",
-    slug: "voronoi-tooltips-grouped",
-    code: require("!!raw!../screens/gallery/examples/voronoi-tooltips-grouped.example.js")
+    text: "Multiple Dependent Axes",
+    slug: "multiple-dependent-axes",
+    code: require("!!raw!../screens/gallery/examples/multi-axis.example.js")
   }, {
     text: "Victory Line with null data",
     slug: "victory-line-null-data",
     code: require("!!raw!../screens/gallery/examples/victory-line-null-data.example.js")
   }, {
-    text: "Multiple Dependent Axes",
-    slug: "multiple-dependent-axes",
-    code: require("!!raw!../screens/gallery/examples/multi-axis.example.js")
+    text: "Voronoi Tooltips with Grouped Components",
+    slug: "voronoi-tooltips-grouped",
+    code: require("!!raw!../screens/gallery/examples/voronoi-tooltips-grouped.example.js")
+  }, {
+    text: "Rainbow Gradient Fill",
+    slug: "rainbow-gradient",
+    code: require("!!raw!../screens/gallery/examples/rainbow-gradient.example.js")
   }
 ];

--- a/src/components/config-gallery.js
+++ b/src/components/config-gallery.js
@@ -79,5 +79,9 @@ export const configGallery = [
     text: "Victory Line with null data",
     slug: "victory-line-null-data",
     code: require("!!raw!../screens/gallery/examples/victory-line-null-data.example.js")
+  }, {
+    text: "Multiple Dependent Axes",
+    slug: "multiple-dependent-axes",
+    code: require("!!raw!../screens/gallery/examples/multi-axis.example.js")
   }
 ];

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -30,8 +30,16 @@ import VVoronoiContainerDocs from "../screens/docs/components/victory-voronoi-co
 import NativeTutorial from "../screens/docs/components/native/index.js";
 import VZoomContainerDocs from "../screens/docs/components/victory-zoom-container/index.js";
 import CreateContainerDocs from "../screens/docs/components/create-container/index.js";
+import FAQDocs from "../screens/docs/components/faq/index.js";
 
 export const config = [
+  {
+    text: "FAQ",
+    slug: "faq",
+    category: "introduction",
+    docs: FAQDocs,
+    toc: FAQDocs.toc()
+  },
   {
     text: "Common Props",
     slug: "common-props",

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -36,7 +36,7 @@ export const config = [
   {
     text: "FAQ",
     slug: "faq",
-    category: "introduction",
+    category: "support",
     docs: FAQDocs,
     toc: FAQDocs.toc()
   },

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -29,6 +29,9 @@ class VictoryHeader extends React.Component {
           <Link to="/docs">
             Docs
           </Link>
+          <Link to="/docs/faq">
+            FAQ
+          </Link>
           <Link to="/guides">
             Guides
           </Link>

--- a/src/components/sidebar/list.js
+++ b/src/components/sidebar/list.js
@@ -42,7 +42,7 @@ class SidebarList extends React.Component {
             return subheading.text ? this.isMatchingNode(subheading) : true;
           })
           .map((subheading, subheadingIndex) => {
-            const text = !subheading.text || subheading.text === "none" ?
+            const text = !subheading.text || subheading.text === "none" || subheading.text === "introduction" ?
               null : (
               <p className="Sidebar-SubHeading SubHeading">
                 {subheading.text}

--- a/src/components/sidebar/list.js
+++ b/src/components/sidebar/list.js
@@ -42,7 +42,7 @@ class SidebarList extends React.Component {
             return subheading.text ? this.isMatchingNode(subheading) : true;
           })
           .map((subheading, subheadingIndex) => {
-            const text = !subheading.text || subheading.text === "none" || subheading.text === "introduction" ?
+            const text = !subheading.text || subheading.text === "none" || subheading.text === "support" ?
               null : (
               <p className="Sidebar-SubHeading SubHeading">
                 {subheading.text}

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -1,35 +1,302 @@
-# Frequently Asked Questions (FAQ) 
+# Frequently Asked Questions (FAQ)
 
-## How can I format my axis labels?
+## Styles
+
+### How can I change the colors of lines and other elements in Victory?
+
+Most components in Victory use a standard `style` prop with style namespaces for "data" and "labels". Any styles added to the "data" namespace will be applied to all the svg elements rendered for a given dataset.
 
 ```playground
-  <VictoryChart />
+<VictoryChart domain={{ x: [0, 4] }}>
+  <VictoryBar
+    style={{ data: { fill: "red" } }}
+    data={[
+      { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 6 }
+    ]}
+  />
+  <VictoryLine
+    style={{ data: { stroke: "blue", strokeWidth: 5 } }}
+    y={(d) => d.x}
+  />
+</VictoryChart>
 ```
 
-## How can I change the colors of lines and other elements in Victory?
+### How can I change the color of an individual point or bar?
 
-## How can I style axes in `VictoryChart`?
+Individual elements in Victory can be styled by adding style attributes directly to your data object. Functional styles and props can also be used to change the appearance of an element based on the data point it represents.
 
-## Why are my labels cut off?
+```playground
+<VictoryChart>
+  <VictoryBar
+    data={[
+      { x: 1, y: 2, fill: "red", width: 5 },
+      { x: 2, y: 4 , fill: "orange", width: 10},
+      { x: 3, y: 6, fill: "gold", width: 20 }
+    ]}
+  />
+  <VictoryScatter
+    style={{ data: {
+      fill: (d) => d.x > 2 ? "blue" : "grey",
+      stroke: (d) => d.y < 6 ? "red" : "black",
+      strokeWidth: 2
+    } }}
+    symbol={(d) => d.x > 1 ? "plus" : "square"}
+    size={(d) => d.y + 2}
+    data={[
+       { x: 0, y: 2 }, { x: 1, y: 4 }, { x: 2, y: 6 }, { x: 3, y: 8 }, { x: 4, y: 10 }
+    ]}
+  />
+</VictoryChart>
+```
+Note that continuous data types such as `VictoryLine` and `VictoryArea` cannot be styled in this way, as they only render a single element for a given dataset.
 
-## How can I add tooltips to a line?
+### How can I use gradient fills in Victory?
 
-## How can I add my own events when I'm using `VictoryTooltip`?
+Create a gradient def as usual and then reference it by id in your style object. A more complicated example using gradient fills can be found [here](https://formidable.com/open-source/victory/gallery/stream-graph)
 
-## Why is my dependingAxis label overlapping my dependentAxis tickLabels?
+```playground
+<div>
+  <svg>
+    <defs>
+      <linearGradient id="myGradient">
+        <stop offset="0%" stopColor="red"/>
+        <stop offset="25%" stopColor="orange"/>
+        <stop offset="50%" stopColor="gold"/>
+        <stop offset="75%" stopColor="yellow"/>
+        <stop offset="100%" stopColor="green"/>
+      </linearGradient>
+    </defs>
+  </svg>
+  <VictoryChart>
+    <VictoryArea
+      style={{
+        data: {fill: "url(#myGradient)"}
+      }}
+      data={[
+        { x: 1, y: 2 },
+        { x: 2, y: 3 },
+        { x: 3, y: 7 },
+        { x: 4, y: 4 },
+        { x: 5, y: 5 }
+      ]}
+    />
+  </VictoryChart>
+</div>
+```
 
-## How can I remove the axis from a chart and only display the graphics?
+## Annotations
 
-## Does VictoryJS have any map components?
+### How can I add arbitrary labels to my charts?
 
-## Why are my bars in my bar chart overlapping with the axis?
+Use `VictoryLabel` to as a child of `VictoryChart` to add arbitrary labels. Labels can be positioned with the `x` and `y` props, or with `datum` when used within `VictoryChart` or `VictoryGroup`.
 
-## How do I get `VictoryVoronoiContainer` to work with `VictoryTooltip` (maybe already covered by how can I add tooltips to a line)?
+```playground
+<VictoryChart domain={[0, 10]}>
+  <VictoryLabel text="Chart Title" x={225} y={30} textAnchor="middle"/>
+  <VictoryLine
+    style={{ data: { stroke: "blue", strokeWidth: 5 } }}
+    y={(d) => d.x}
+  />
+  <VictoryLabel text="Annotation" datum={{ x: 4, y: 6 }} textAnchor="middle"/>
+</VictoryChart>
+```
 
-## How do I add my own custom graphics to the chart (ex. a watermark or a logo)?
 
-## Does `VictoryChart` support server-side rendering with something like next.js?
+### How can I annotate my charts with lines and markers?
 
-## How do I make my charts exportable (save as image)?
+Victory doesn't have specific components for annotations. Instead, use standard component such as `VictoryLine` and `VictoryScatter` to add lines and markers to your chart.
 
-## How do I make tooltips always visible?
+```playground
+<VictoryChart domain={[0, 10]}>
+  <VictoryLine
+    style={{ data: { stroke: "blue", strokeWidth: 3 } }}
+    y={(d) => d.x}
+  />
+  <VictoryLine
+    style={{
+      data: { stroke: "red", strokeWidth: 2 },
+      labels: { angle: -90, fill: "red", fontSize: 20 }
+    }}
+    labels={["Important"]}
+    labelComponent={<VictoryLabel y={100}/>}
+    x={() => 5}
+  />
+  <VictoryScatter
+    data={[{ x: 5, y: 5, fill: "red", symbol: "star", size: 8 }]}
+  />
+</VictoryChart>
+```
+
+## Axes
+
+### How do I turn off the axes on VictoryChart?
+
+`VictoryChart` uses default axes. If you want to plot data without using any axes, use `VictoryGroup` instead.
+
+```playground
+<VictoryGroup>
+  <VictoryBar
+    style={{ data: { fill: "red" } }}
+    data={[
+      { x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 6 }
+    ]}
+  />
+  <VictoryLine domain={{ x: [0, 4] }}
+    style={{ data: { stroke: "blue", strokeWidth: 5 } }}
+    y={(d) => d.x}
+  />
+</VictoryGroup>
+```
+
+### Why is VictoryChart rendering only one axis?
+
+When no axes are supplied to `VictoryChart` it will render pair of default axes. If any axes are supplied as children to `VictoryChart` it will render _only_ those axes.
+
+```playground
+<div style={{ display: "flex", flexWrap: "wrap" }}>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Default Axes" x={225} y={30} textAnchor="middle"/>
+    <VictoryLine/>
+  </VictoryChart>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Two VictoryAxis Children" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis/>
+    <VictoryAxis dependentAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Single Dependent Axis" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Single Independent Axis" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+</div>
+```
+
+### How can I change the position of my axis?
+
+`VictoryChart` automatically aligns axes so that they cross at their origin. Use the `offsetX` and `offsetY` props on `VictoryAxis` to alter this default behavior. *Note:* Axes that typically cross at zero will not display ticks or tick labels at zero. To change this behavior, set the `crossAxis` prop to false.
+[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+
+```playground
+<VictoryChart domain={{ y: [-10, 10] }}>
+  <VictoryAxis offsetY={50}/>
+  <VictoryAxis dependentAxis offsetX={50} crossAxis={false}/>
+  <VictoryLine/>
+</VictoryChart>
+```
+
+
+### How can I format my axis labels?
+
+Axis tick labels are controlled via two props. `tickValues` controls the _positions_ of ticks along the axis, and `tickFormat` controls how labels are displayed. Use the `tickFormat` prop to customize axis labels. This prop can be given as an array of strings, or as a function that returns a string. Functions provided to `tickFormat` are called with the following arguments: `tickValue`, `index` and `tickArray`.
+[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+
+```playground
+<VictoryChart domain={[0, 5]}>
+  <VictoryAxis tickValues={[1, 2, 3, 4]} tickFormat={["first", "second", "third", "fourth"]}/>
+  <VictoryAxis dependentAxis tickFormat={(tick) => `$${Math.round(tick)}M`}/>
+  <VictoryLine/>
+</VictoryChart>
+```
+
+### My axis labels are cut off. How can I fix them?
+
+Long axis labels can be problematic. There are several ways to address the issue. The best solution will depend on the specific requirements of your project. The following examples demonstrate:
+- Altering `padding`
+- Splitting labels onto multiple lines
+- Using angled labels
+- Allowing labels to overflow the container with VictoryPortal
+
+```playground
+<div style={{ display: "flex", flexWrap: "wrap" }}>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}
+    padding={{ left: 90, top: 50, right: 10, bottom: 50 }}
+  >
+    <VictoryLabel text="Altering padding" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis
+      tickFormat={[
+        "first label",
+        "second label",
+        "third label",
+        "forth label"
+      ]}
+    />
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Splitting Labels into multiple lines" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis
+      tickFormat={[
+        `first\nlabel`,
+        `second\nlabel`,
+        `third\nlabel`,
+        `forth\nlabel`,
+        `fifth\nlabel`
+      ]}
+    />
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Angled labels" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis
+      style={{ tickLabels: { angle: -60 } }}
+      tickFormat={[
+        "first label",
+        "second label",
+        "third label",
+        "forth label",
+        "fifth label"
+      ]}
+    />
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="overflowing labels with VictoryPortal" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis
+      tickLabelComponent={<VictoryPortal><VictoryLabel/></VictoryPortal>}
+      tickFormat={[
+        "first label",
+        "second label",
+        "third label",
+        "forth label",
+        "fifth label"
+      ]}
+    />
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+</div>
+```
+
+## Labels and Tooltips
+
+### How can I add tooltips to a line?
+
+`VictoryLine` only renders a single element to represent an entire dataset, so replacing its `labelComponent` with `VictoryTooltip` wont work as expected, since there will be only a single event trigger. Voronoi tooltips can be used to add tooltips and other interactions components without unique event triggers, or with event triggers that are too small, or too close together to be useful. Use `VictoryVoronoiContainer` to associate mouse position with the nearest data points. [Read more about Voronoi Tooltips](https://formidable.com/open-source/victory/guides/tooltips#tooltips-with-victoryvoronoicontainer) and [`VictoryVoronoiContainer`](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+
+
+### How can I add my own events when I'm using `VictoryTooltip`?
+
+`VictoryTooltip` uses `defaultEvents` which are prepended onto any events array provided in props. When `events` container `onMouseOver` and `onMouseOut` events, they will interfere with the `defaultEvents` on `VictoryTooltip` to correct this, your events prop will need to return the same mutations as `defaultEvents`. [Read about tooltip events here](https://formidable.com/open-source/victory/guides/tooltips)
+
+### Why are my bars in my bar chart overlapping with the axis?
+### How can I make responsive charts?
+
+## Containers and Behaviors
+
+### Why isn't my container working?
+### How can I make a chart with voronoi tooltips that can also zoom?
+
+
+

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -1,0 +1,31 @@
+# Frequently Asked Questions (FAQ) 
+
+## How can I format my axis labels?
+
+## How can I change the colors of lines and other elements in Victory?
+
+## How can I style axes in `VictoryChart`?
+
+## Why are my labels cut off?
+
+## How can I add tooltips to a line?
+
+## How can I add my own events when I'm using `VictoryTooltip`?
+
+## Why is my dependingAxis label overlapping my dependentAxis tickLabels?
+
+## How can I remove the axis from a chart and only display the graphics?
+
+## Does VictoryJS have any map components?
+
+## Why are my bars in my bar chart overlapping with the axis?
+
+## How do I get `VictoryVoronoiContainer` to work with `VictoryTooltip` (maybe already covered by how can I add tooltips to a line)?
+
+## How do I add my own custom graphics to the chart (ex. a watermark or a logo)?
+
+## Does `VictoryChart` support server-side rendering with something like next.js?
+
+## How do I make my charts exportable (save as image)?
+
+## How do I make tooltips always visible?

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -1,5 +1,7 @@
 # Frequently Asked Questions (FAQ)
 
+Thanks for trying Victory! The FAQs below are based on issues and questions from our [support channel](https://gitter.im/FormidableLabs/victory). You can find more examples in [our gallery](https://formidable.com/open-source/victory/gallery). Can't find what you're looking for? Help us improve these docs by [opening an issue](https://github.com/FormidableLabs/victory-docs/issues/new).
+
 ## Styles
 
 ### How can I change the colors of lines and other elements in Victory?
@@ -177,10 +179,14 @@ When no axes are supplied to `VictoryChart` it will render pair of default axes.
 </div>
 ```
 
+### Can I make a chart with multiple dependent axes?
+
+`VictoryChart` will render any number of dependent axes, but only one independent axis. All children rendered by `VictoryChart` will be forced to use the same domain. To create a single chart with the appearance of several different domains, you can either compose components manually without the aid of `VictoryChart`, as described in [this guide](https://formidable.com/open-source/victory/guides/custom-charts), or normalize all of your data, and re-scale your axis tick labels to give the appearance of separate domains as in [this example](https://formidable.com/open-source/victory/gallery/multiple-dependent-axes).
+
 ### How can I change the position of my axis?
 
 `VictoryChart` automatically aligns axes so that they cross at their origin. Use the `offsetX` and `offsetY` props on `VictoryAxis` to alter this default behavior. *Note:* Axes that typically cross at zero will not display ticks or tick labels at zero. To change this behavior, set the `crossAxis` prop to false.
-[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis).
 
 ```playground
 <VictoryChart domain={{ y: [-10, 10] }}>
@@ -190,11 +196,10 @@ When no axes are supplied to `VictoryChart` it will render pair of default axes.
 </VictoryChart>
 ```
 
-
 ### How can I format my axis labels?
 
 Axis tick labels are controlled via two props. `tickValues` controls the _positions_ of ticks along the axis, and `tickFormat` controls how labels are displayed. Use the `tickFormat` prop to customize axis labels. This prop can be given as an array of strings, or as a function that returns a string. Functions provided to `tickFormat` are called with the following arguments: `tickValue`, `index` and `tickArray`.
-[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+[Read more about VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis).
 
 ```playground
 <VictoryChart domain={[0, 5]}>
@@ -223,7 +228,8 @@ Long axis labels can be problematic. There are several ways to address the issue
         "first label",
         "second label",
         "third label",
-        "forth label"
+        "forth label",
+        "fifth label"
       ]}
     />
     <VictoryAxis/>
@@ -283,20 +289,96 @@ Long axis labels can be problematic. There are several ways to address the issue
 
 ### How can I add tooltips to a line?
 
-`VictoryLine` only renders a single element to represent an entire dataset, so replacing its `labelComponent` with `VictoryTooltip` wont work as expected, since there will be only a single event trigger. Voronoi tooltips can be used to add tooltips and other interactions components without unique event triggers, or with event triggers that are too small, or too close together to be useful. Use `VictoryVoronoiContainer` to associate mouse position with the nearest data points. [Read more about Voronoi Tooltips](https://formidable.com/open-source/victory/guides/tooltips#tooltips-with-victoryvoronoicontainer) and [`VictoryVoronoiContainer`](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+`VictoryLine` only renders a single element to represent an entire dataset, so replacing its `labelComponent` with `VictoryTooltip` wont work as expected, since there will be only a single event trigger. Voronoi tooltips can be used to add tooltips and other interactions components without unique event triggers, or with event triggers that are too small, or too close together to be useful. Use `VictoryVoronoiContainer` to associate mouse position with the nearest data points. [Read more about Voronoi Tooltips](https://formidable.com/open-source/victory/guides/tooltips#tooltips-with-victoryvoronoicontainer) and [`VictoryVoronoiContainer`](https://formidable.com/open-source/victory/docs/victory-voronoi-container).
 
 
 ### How can I add my own events when I'm using `VictoryTooltip`?
 
-`VictoryTooltip` uses `defaultEvents` which are prepended onto any events array provided in props. When `events` container `onMouseOver` and `onMouseOut` events, they will interfere with the `defaultEvents` on `VictoryTooltip` to correct this, your events prop will need to return the same mutations as `defaultEvents`. [Read about tooltip events here](https://formidable.com/open-source/victory/guides/tooltips)
+`VictoryTooltip` uses `defaultEvents` which are prepended onto any events array provided in props. When `events` container `onMouseOver` and `onMouseOut` events, they will interfere with the `defaultEvents` on `VictoryTooltip` to correct this, your events prop will need to return the same mutations as `defaultEvents`. [Read about tooltip events here](https://formidable.com/open-source/victory/guides/tooltips).
 
-### Why are my bars in my bar chart overlapping with the axis?
-### How can I make responsive charts?
+## Layout
+
+### Why are the bars in my bar chart overlapping with the axis?
+
+Bars in `VictoryBar` are centered around their corresponding value by default. You can move your bars away from your axis by setting a new domain, adding a `domainPadding`, or changing how bars are aligned relative to their values with the `alignment` prop on `VictoryBar`.
+
+```playground
+<div style={{ display: "flex", flexWrap: "wrap" }}>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}
+    domainPadding={{ x: 15 }}
+  >
+    <VictoryLabel text="domainPadding" x={225} y={30} textAnchor="middle"/>
+    <VictoryBar
+      style={{ data: { fill: "gold", width: 30 } }}
+    />
+  </VictoryChart>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="alignment" x={225} y={30} textAnchor="middle"/>
+    <VictoryBar
+      alignment="start"
+      style={{ data: { fill: "gold" } }}
+    />
+  </VictoryChart>
+</div>
+```
+
+
+### How can I change the size of my chart?
+
+By default Victory components are rendered within responsive SVGs that preserve the aspect ratio set by the `width` and `height` props. Charts will automatically scale to fit within parent elements while maintaining a set aspect ratio. The size of your chart may be changed by rendering it within a smaller container. The aspect ratio of the chart may be changed by altering the width and height props. The default responsive behavior may also be disabled by setting `responsive={false}` on any Victory container.
+
+```playground
+<div style={{ display: "flex", flexWrap: "wrap" }}>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="Default Sizing" x={225} y={30} textAnchor="middle"/>
+    <VictoryLine/>
+  </VictoryChart>
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}
+    width={600} height={200}
+  >
+    <VictoryLabel text="New Aspect Ratio" x={225} y={30} textAnchor="middle"/>
+    <VictoryLine/>
+  </VictoryChart>
+  <VictoryChart
+    width={600} height={200}
+    containerComponent={<VictoryContainer responsive={false}/>}
+  >
+    <VictoryLabel text="Non-responsive" x={225} y={30} textAnchor="middle"/>
+    <VictoryLine/>
+  </VictoryChart>
+</div>
+```
 
 ## Containers and Behaviors
 
-### Why isn't my container working?
+### How can I use containers in Victory?
+
+Victory renders charts into top-level container components. The most basic container is `VictoryContainer`. It is responsible for rendering children into a responsive svg, and providing a portal component for rendering tooltips, or any other elements that should be rendered above everything else. Other Victory container, such as `VictoryZoomContainer` and `VictoryCursorContainer` provide an interactive layer for the chart. These containers perform all the same functions as `VictoryContainer` in addition to their specialized functions.
+
+- [`VictoryZoomContainer`](https://formidable.com/open-source/victory/docs/victory-zoom-container): Adds pan and zoom functionality to a chart
+- [`VictoryVoronoiContainer`](https://formidable.com/open-source/victory/docs/victory-voronoi-container): Associates mouse position with the nearest data points, and is useful for tooltips and other hover interactions
+- [`VictorySelectionContainer`](https://formidable.com/open-source/victory/docs/victory-selection-container): Adds the ability to select points within a region
+- [`VictoryBrushContainer`](https://formidable.com/open-source/victory/docs/victory-brush-container): Adds a moveable highlighted region to charts
+- [`VictoryCursorContainer`](https://formidable.com/open-source/victory/docs/victory-cursor-container): Renders a cursor line and label that follows mouse position.
+
+To use one of these containers, change the `containerComponent` prop on your _top-level_ Victory component. *Note:* Containers are not rendered when `standalone` is set to `false`.
+
+```playground
+<VictoryChart
+  domainPadding={{ y: 10 }}
+  containerComponent={
+    <VictoryZoomContainer/>
+  }
+>
+  <VictoryScatter
+    y={(datum) => Math.sin(2 * Math.PI * datum.x)}
+  />
+</VictoryChart>
+```
+
 ### How can I make a chart with voronoi tooltips that can also zoom?
+
+Victory includes a `createContainer` helper that is used to create hybrid containers. `createContainer` can be used to create a new container with behaviors from two existing Victory containers. [Read more about `createContainer` here](https://formidable.com/open-source/victory/docs/create-container).
 
 
 

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -58,7 +58,7 @@ Create a gradient def as usual and then reference it by id in your style object.
 
 ```playground
 <div>
-  <svg>
+  <svg style={{ height: 0 }}>
     <defs>
       <linearGradient id="myGradient">
         <stop offset="0%" stopColor="red"/>

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -2,6 +2,10 @@
 
 ## How can I format my axis labels?
 
+```playground
+  <VictoryChart />
+```
+
 ## How can I change the colors of lines and other elements in Victory?
 
 ## How can I style axes in `VictoryChart`?

--- a/src/screens/docs/components/faq/ecology.md
+++ b/src/screens/docs/components/faq/ecology.md
@@ -214,8 +214,8 @@ Axis tick labels are controlled via two props. `tickValues` controls the _positi
 Long axis labels can be problematic. There are several ways to address the issue. The best solution will depend on the specific requirements of your project. The following examples demonstrate:
 - Altering `padding`
 - Splitting labels onto multiple lines
-- Using angled labels
 - Allowing labels to overflow the container with VictoryPortal
+- Using angled labels
 
 ```playground
 <div style={{ display: "flex", flexWrap: "wrap" }}>
@@ -237,7 +237,7 @@ Long axis labels can be problematic. There are several ways to address the issue
   </VictoryChart>
 
   <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
-    <VictoryLabel text="Splitting Labels into multiple lines" x={225} y={30} textAnchor="middle"/>
+    <VictoryLabel text="Multi-line labels" x={225} y={30} textAnchor="middle"/>
     <VictoryAxis dependentAxis
       tickFormat={[
         `first\nlabel`,
@@ -245,6 +245,23 @@ Long axis labels can be problematic. There are several ways to address the issue
         `third\nlabel`,
         `forth\nlabel`,
         `fifth\nlabel`
+      ]}
+    />
+    <VictoryAxis/>
+    <VictoryLine/>
+  </VictoryChart>
+
+
+  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+    <VictoryLabel text="overflowing labels with VictoryPortal" x={225} y={30} textAnchor="middle"/>
+    <VictoryAxis dependentAxis
+      tickLabelComponent={<VictoryPortal><VictoryLabel/></VictoryPortal>}
+      tickFormat={[
+        "first label",
+        "second label",
+        "third label",
+        "forth label",
+        "fifth label"
       ]}
     />
     <VictoryAxis/>
@@ -267,21 +284,6 @@ Long axis labels can be problematic. There are several ways to address the issue
     <VictoryLine/>
   </VictoryChart>
 
-  <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
-    <VictoryLabel text="overflowing labels with VictoryPortal" x={225} y={30} textAnchor="middle"/>
-    <VictoryAxis dependentAxis
-      tickLabelComponent={<VictoryPortal><VictoryLabel/></VictoryPortal>}
-      tickFormat={[
-        "first label",
-        "second label",
-        "third label",
-        "forth label",
-        "fifth label"
-      ]}
-    />
-    <VictoryAxis/>
-    <VictoryLine/>
-  </VictoryChart>
 </div>
 ```
 

--- a/src/screens/docs/components/faq/index.js
+++ b/src/screens/docs/components/faq/index.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import * as Victory from "victory";
+import EcologyRecipe from "../../../../components/ecology-recipe";
+import markdown from "../../../../markdown";
+const overview = require("!!raw!./ecology.md");
+
+class VictoryFAQ extends React.Component {
+  static toc() {
+    return markdown.parseToc(overview);
+  }
+
+  render() {
+    return (
+      <EcologyRecipe
+        overview={overview}
+        location={this.props.location}
+        scope={{ ...Victory, React }}
+      />
+    );
+  }
+}
+
+VictoryFAQ.propTypes = {
+  location: PropTypes.object.isRequired
+};
+
+export default VictoryFAQ;

--- a/src/screens/docs/components/index.md
+++ b/src/screens/docs/components/index.md
@@ -424,5 +424,5 @@ For more information about Victory and its components, check out the docs - see 
 
 [our guides]: https://formidable.com/open-source/victory/guides
 [Gallery]: https://formidable.com/open-source/victory/gallery
-[FAQs]: https://formidable.com/open-source/victory/faqs
+[FAQs]: https://formidable.com/open-source/victory/faq
 [Check out the native version of this getting started tutorial]: https://formidable.com/open-source/victory/docs/native

--- a/src/screens/docs/components/index.md
+++ b/src/screens/docs/components/index.md
@@ -1,6 +1,6 @@
 # Getting Started with Victory
 
-Victory is an opinionated, but fully overridable, ecosystem of composable React components for building interactive data visualizations. The following tutorial should help you get started with Victory. For more advanced examples, check out [our guides].
+Victory is an opinionated, but fully overridable, ecosystem of composable React components for building interactive data visualizations. The following tutorial explains how to set up a basic chart. For next steps, please see our [FAQs] and [Gallery] sections. For more advanced examples, check out [our guides].
 
 #### Getting Started with Victory Native?
 
@@ -414,9 +414,15 @@ class App extends React.Component {
 ReactDOM.render(<App/>, mountNode);
 ```
 
+## Next Steps
+
+Congratulations! You’ve created your first chart with Victory. Next, check out our [FAQs] and [Gallery] for more examples and information. Happy charting.
+
 ## Documentation, Contributing, and Source
 
-Congratulations! You’ve created your first chart with Victory. For more information about Victory and its components, check out the docs - see [VictoryChart](http://formidable.com/open-source/victory/docs/victory-chart) to get started. Interested in helping out or seeing what's happening under the hood? Victory is maintained at [github.com/FormidableLabs/victory](https://github.com/FormidableLabs/victory), and you can [start contributing here](https://github.com/FormidableLabs/victory/#contributing). Happy charting.
+For more information about Victory and its components, check out the docs - see [VictoryChart](http://formidable.com/open-source/victory/docs/victory-chart) to get started. Interested in helping out or seeing what's happening under the hood? Victory is maintained at [github.com/FormidableLabs/victory](https://github.com/FormidableLabs/victory), and you can [start contributing here](https://github.com/FormidableLabs/victory/#contributing).
 
 [our guides]: https://formidable.com/open-source/victory/guides
+[Gallery]: https://formidable.com/open-source/victory/gallery
+[FAQs]: https://formidable.com/open-source/victory/faqs
 [Check out the native version of this getting started tutorial]: https://formidable.com/open-source/victory/docs/native

--- a/src/screens/docs/components/victory-polar-axis/ecology.md
+++ b/src/screens/docs/components/victory-polar-axis/ecology.md
@@ -145,7 +145,7 @@ The `dependentAxis` boolean prop specifies whether the axis corresponds to the d
 *default:* `dependentAxis={false}`
 
 ```playground
-<div style={{ margin: 50 }}>
+<div>
   <VictoryPolarAxis dependentAxis theme={VictoryTheme.material} />
   <VictoryPolarAxis theme={VictoryTheme.material} />
 </div>
@@ -175,7 +175,7 @@ The `endAngle` props defines the overall end angle of the axis in degrees. This 
 
 
 ```playground
-<div style={{ margin: 50 }}>
+<div>
 <VictoryPolarAxis
   startAngle={90}
   endAngle={450}
@@ -322,7 +322,7 @@ The `startAngle` props defines the overall end angle of the axis in degrees. Thi
 
 
 ```playground
-<div style={{ margin: 50 }}>
+<div>
   <VictoryPolarAxis
     startAngle={90}
     endAngle={450}

--- a/src/screens/docs/components/victory-polar-axis/ecology.md
+++ b/src/screens/docs/components/victory-polar-axis/ecology.md
@@ -145,7 +145,7 @@ The `dependentAxis` boolean prop specifies whether the axis corresponds to the d
 *default:* `dependentAxis={false}`
 
 ```playground
-<div>
+<div style={{ display: "flex" }}>
   <VictoryPolarAxis dependentAxis theme={VictoryTheme.material} />
   <VictoryPolarAxis theme={VictoryTheme.material} />
 </div>
@@ -175,7 +175,7 @@ The `endAngle` props defines the overall end angle of the axis in degrees. This 
 
 
 ```playground
-<div>
+<div style={{ display: "flex" }}>
 <VictoryPolarAxis
   startAngle={90}
   endAngle={450}
@@ -322,7 +322,7 @@ The `startAngle` props defines the overall end angle of the axis in degrees. Thi
 
 
 ```playground
-<div>
+<div style={{ display: "flex" }}>
   <VictoryPolarAxis
     startAngle={90}
     endAngle={450}

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -30,7 +30,7 @@ class Docs extends React.Component {
   renderContent(activePageConf, location) {
     if (activePageConf.slug === "index") {
       return (
-        <div className="Markdown playgroundsMaxHeight">
+        <div className="Recipe Markdown">
           <a href="https://github.com/FormidableLabs/victory-docs/blob/master/docs/index.md" className="SubHeading">Edit this page</a>
           <EcologyLinkable
             overview={require("!!raw!./components/index.md")}

--- a/src/screens/gallery/examples/multi-axis.example.js
+++ b/src/screens/gallery/examples/multi-axis.example.js
@@ -3,7 +3,7 @@
   will be removed before displaying this document to the user
 */
 /* global React, ReactDOM, App, mountNode */
-/* global VictoryChart, VictoryLine, VictoryAxis */
+/* global VictoryChart, VictoryLine, VictoryAxis, VictoryTheme */
 
 const data = [
   [{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}, {x: 4, y: 4}],
@@ -25,7 +25,11 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <VictoryChart domain={{ y: [0, 1] }} width={400}>
+        <VictoryChart
+          theme={VictoryTheme.material}
+          width={400} height={400}
+          domain={{ y: [0, 1] }}
+        >
          <VictoryAxis />
           {data.map((d, i) =>
             <VictoryAxis dependentAxis

--- a/src/screens/gallery/examples/multi-axis.example.js
+++ b/src/screens/gallery/examples/multi-axis.example.js
@@ -1,0 +1,60 @@
+/* NOTE
+  all one-line star comments starting with "eslint", "global", or "NOTE"
+  will be removed before displaying this document to the user
+*/
+/* global React, ReactDOM, App, mountNode */
+/* global VictoryChart, VictoryLine, VictoryAxis */
+
+const data = [
+  [{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}, {x: 4, y: 4}],
+  [{x: 1, y: 400}, {x: 2, y: 350}, {x: 3, y: 300}, {x: 4, y: 250}],
+  [{x: 1, y: 75}, {x: 2, y: 85}, {x: 3, y: 95}, {x: 4, y: 100}]
+];
+// find maxima for normalizing data
+const maxima = data.map(
+	(dataset) => Math.max(...dataset.map((d) => d.y))
+);
+
+const xOffsets = [50, 200, 350];
+const tickPadding = [ 0, 0, -15 ];
+const anchors = ["end", "end", "start"];
+const colors = ["black", "red", "blue"];
+
+class App extends React.Component {
+
+  render() {
+    return (
+      <div>
+        <VictoryChart domain={{ y: [0, 1] }} width={400}>
+         <VictoryAxis />
+          {data.map((d, i) =>
+            <VictoryAxis dependentAxis
+              key={i}
+              offsetX={xOffsets[i]}
+              style={{
+                axis: { stroke: colors[i] },
+                ticks: { padding: tickPadding[i] },
+                tickLabels: { fill: colors[i], textAnchor: anchors[i] }
+              }}
+              // Use normalized tickValues (0 - 1)
+              tickValues={[0.25, 0.5, 0.75, 1]}
+              // Re-scale ticks by multiplying by correct maxima
+              tickFormat={(t) => t * maxima[i]}
+            />
+          )}
+          {data.map((d, i) =>
+            <VictoryLine
+              key={i}
+              data={d}
+              style={{ data: { stroke: colors[i] } }}
+              // normalize data
+              y={(datum) => datum.y / maxima[i]}
+            />
+          )}
+        </VictoryChart>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App/>, mountNode);

--- a/src/screens/gallery/examples/rainbow-gradient.example.js
+++ b/src/screens/gallery/examples/rainbow-gradient.example.js
@@ -1,0 +1,45 @@
+/* NOTE
+  all one-line star comments starting with "eslint", "global", or "NOTE"
+  will be removed before displaying this document to the user
+*/
+/* global React, ReactDOM, App, mountNode */
+/* global VictoryChart, VictoryArea, VictoryTheme */
+
+class App extends React.Component {
+  render() {
+    return (
+      <div>
+        <svg style={{ height: 0 }}>
+          <defs>
+            <linearGradient id="myGradient">
+              <stop offset="0%" stopColor="red"/>
+              <stop offset="25%" stopColor="red"/>
+              <stop offset="25%" stopColor="orange"/>
+              <stop offset="50%" stopColor="orange"/>
+              <stop offset="50%" stopColor="gold"/>
+              <stop offset="75%" stopColor="gold"/>
+              <stop offset="75%" stopColor="green"/>
+              <stop offset="100%" stopColor="green"/>
+            </linearGradient>
+          </defs>
+        </svg>
+        <VictoryChart theme={VictoryTheme.material}>
+          <VictoryArea
+            style={{
+              data: {fill: "url(#myGradient)"}
+            }}
+            data={[
+              { x: 1, y: 2 },
+              { x: 2, y: 3 },
+              { x: 3, y: 7 },
+              { x: 4, y: 4 },
+              { x: 5, y: 5 }
+            ]}
+          />
+        </VictoryChart>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App/>, mountNode);

--- a/src/screens/guides/components/custom-charts/ecology.md
+++ b/src/screens/guides/components/custom-charts/ecology.md
@@ -197,7 +197,7 @@ class CustomTheme extends React.Component {
         display: "inline",
         padding: 0,
         fontFamily: "'Fira Sans', sans-serif",
-        width: "100%",
+        maxWidth: "50%",
         height: "auto"
       },
       title: {

--- a/src/screens/guides/components/custom-charts/ecology.md
+++ b/src/screens/guides/components/custom-charts/ecology.md
@@ -194,7 +194,6 @@ class CustomTheme extends React.Component {
         boxSizing: "border-box",
         display: "inline",
         padding: 0,
-        margin: 20,
         fontFamily: "'Fira Sans', sans-serif",
         width: "100%",
         height: "auto"

--- a/src/screens/guides/components/custom-charts/ecology.md
+++ b/src/screens/guides/components/custom-charts/ecology.md
@@ -17,110 +17,112 @@ class CustomTheme extends React.Component {
     const tickValues = this.getTickValues();
 
     return (
-      <svg style={styles.parent} viewBox="0 0 450 350">
+      <div>
+        <svg style={styles.parent} viewBox="0 0 450 350">
 
-        {/* Create stylistic elements */}
-        <rect x="0" y="0" width="10" height="30" fill="#f01616"/>
-        <rect x="420" y="10" width="20" height="20" fill="#458ca8"/>
+          {/* Create stylistic elements */}
+          <rect x="0" y="0" width="10" height="30" fill="#f01616"/>
+          <rect x="420" y="10" width="20" height="20" fill="#458ca8"/>
 
-        {/* Define labels */}
-        <VictoryLabel x={25} y={24} style={styles.title}
-          text="An outlook"
-        />
-        <VictoryLabel x={430} y={20} style={styles.labelNumber}
-          text="1"
-        />
-        <VictoryLabel x={25} y={55} style={styles.labelOne}
-          text={"Economy \n % change on a year earlier"}
-        />
-        <VictoryLabel x={425} y={55} style={styles.labelTwo}
-          text={"Dinosaur exports\n $bn"}
-        />
+          {/* Define labels */}
+          <VictoryLabel x={25} y={24} style={styles.title}
+            text="An outlook"
+          />
+          <VictoryLabel x={430} y={20} style={styles.labelNumber}
+            text="1"
+          />
+          <VictoryLabel x={25} y={55} style={styles.labelOne}
+            text={"Economy \n % change on a year earlier"}
+          />
+          <VictoryLabel x={425} y={55} style={styles.labelTwo}
+            text={"Dinosaur exports\n $bn"}
+          />
 
-        <g transform={"translate(0, 40)"}>
-          {/* Add shared independent axis */}
-          <VictoryAxis
-            scale="time"
-            standalone={false}
-            style={styles.axisYears}
-            tickValues={tickValues}
-            tickFormat={
-              (x) => {
-                if (x.getFullYear() === 2000) {
-                  return x.getFullYear();
-                }
-                if (x.getFullYear() % 5 === 0) {
-                  return x.getFullYear().toString().slice(2);
+          <g transform={"translate(0, 40)"}>
+            {/* Add shared independent axis */}
+            <VictoryAxis
+              scale="time"
+              standalone={false}
+              style={styles.axisYears}
+              tickValues={tickValues}
+              tickFormat={
+                (x) => {
+                  if (x.getFullYear() === 2000) {
+                    return x.getFullYear();
+                  }
+                  if (x.getFullYear() % 5 === 0) {
+                    return x.getFullYear().toString().slice(2);
+                  }
                 }
               }
-            }
-          />
+            />
 
-          {/*
-            Add the dependent axis for the first data set.
-            Note that all components plotted against this axis will have the same y domain
-          */}
-          <VictoryAxis dependentAxis
-            domain={[-10, 15]}
-            offsetX={50}
-            orientation="left"
-            standalone={false}
-            style={styles.axisOne}
-          />
+            {/*
+              Add the dependent axis for the first data set.
+              Note that all components plotted against this axis will have the same y domain
+            */}
+            <VictoryAxis dependentAxis
+              domain={[-10, 15]}
+              offsetX={50}
+              orientation="left"
+              standalone={false}
+              style={styles.axisOne}
+            />
 
-          {/* Red annotation line */}
-          <VictoryLine
-            data={[
-              {x: new Date(1999, 1, 1), y: 0},
-              {x: new Date(2014, 6, 1), y: 0}
-            ]}
-            domain={{
-              x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
-              y: [-10, 15]
-            }}
-            scale={{x: "time", y: "linear"}}
-            standalone={false}
-            style={styles.lineThree}
-          />
+            {/* Red annotation line */}
+            <VictoryLine
+              data={[
+                {x: new Date(1999, 1, 1), y: 0},
+                {x: new Date(2014, 6, 1), y: 0}
+              ]}
+              domain={{
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
+                y: [-10, 15]
+              }}
+              scale={{x: "time", y: "linear"}}
+              standalone={false}
+              style={styles.lineThree}
+            />
 
-          {/* dataset one */}
-          <VictoryLine
-            data={dataSetOne}
-            domain={{
-              x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
-              y: [-10, 15]
-            }}
-            interpolation="monotoneX"
-            scale={{x: "time", y: "linear"}}
-            standalone={false}
-            style={styles.lineOne}
-          />
+            {/* dataset one */}
+            <VictoryLine
+              data={dataSetOne}
+              domain={{
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
+                y: [-10, 15]
+              }}
+              interpolation="monotoneX"
+              scale={{x: "time", y: "linear"}}
+              standalone={false}
+              style={styles.lineOne}
+            />
 
-          {/*
-            Add the dependent axis for the second data set.
-            Note that all components plotted against this axis will have the same y domain
-          */}
-          <VictoryAxis dependentAxis
-            domain={[0, 50]}
-            orientation="right"
-            standalone={false}
-            style={styles.axisTwo}
-          />
+            {/*
+              Add the dependent axis for the second data set.
+              Note that all components plotted against this axis will have the same y domain
+            */}
+            <VictoryAxis dependentAxis
+              domain={[0, 50]}
+              orientation="right"
+              standalone={false}
+              style={styles.axisTwo}
+            />
 
-          {/* dataset two */}
-          <VictoryLine
-            data={dataSetTwo}
-            domain={{
-              x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
-              y: [0, 50]
-            }}
-            interpolation="monotoneX"
-            scale={{x: "time", y: "linear"}}
-            standalone={false}
-            style={styles.lineTwo}
-          />
-        </g>
-      </svg>
+            {/* dataset two */}
+            <VictoryLine
+              data={dataSetTwo}
+              domain={{
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
+                y: [0, 50]
+              }}
+              interpolation="monotoneX"
+              scale={{x: "time", y: "linear"}}
+              standalone={false}
+              style={styles.lineTwo}
+            />
+          </g>
+        </svg>
+      </div>
     );
   }
 

--- a/src/screens/guides/components/layout/ecology.md
+++ b/src/screens/guides/components/layout/ecology.md
@@ -11,40 +11,37 @@ Victory renders components into responsive `svg` containers by default. Responsi
 Victory renders svg elements, so there is no concept of z-index. Instead the render order of components determines which elements will apprear above others. Changing the order of rendered components can signicantly alter the appearance of a chart. Compare the following charts. The only difference between the two is the order of the children in `VictoryChart`.
 
 ```playground
-  <svg width={800} height={300}>
-    <g>
-      <VictoryChart standalone={false} width={300}>
-        <VictoryScatter
-          y={(data) => Math.sin(2 * Math.PI * data.x)}
-          samples={25}
-          size={5}
-          style={{ data: { fill: "tomato" }}}
-        />
-        <VictoryLine
-          style={{ data: { stroke: "orange" }}}
-          y={(data) => Math.sin(2 * Math.PI * data.x)}
-        />
-        <VictoryAxis/>
-        <VictoryAxis dependentAxis/>
-      </VictoryChart>
-    </g>
-    <g transform={"translate(400, 0)"}>
-      <VictoryChart standalone={false} width={300}>
-        <VictoryAxis/>
-        <VictoryAxis dependentAxis/>
-        <VictoryLine
-          style={{ data: { stroke: "orange" }}}
-          y={(data) => Math.sin(2 * Math.PI * data.x)}
-        />
-        <VictoryScatter
-          y={(data) => Math.sin(2 * Math.PI * data.x)}
-          samples={25}
-          size={5}
-          style={{ data: { fill: "tomato" }}}
-        />
-      </VictoryChart>
-    </g>
-  </svg>
+  <div style={{ display: "flex", flexWrap: "wrap" }}>
+    <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+      <VictoryScatter
+        y={(data) => Math.sin(2 * Math.PI * data.x)}
+        samples={25}
+        size={5}
+        style={{ data: { fill: "tomato" }}}
+      />
+      <VictoryLine
+        style={{ data: { stroke: "orange" }}}
+        y={(data) => Math.sin(2 * Math.PI * data.x)}
+      />
+      <VictoryAxis/>
+      <VictoryAxis dependentAxis/>
+    </VictoryChart>
+
+    <VictoryChart style={{ parent: { maxWidth: "50%" } }}>
+      <VictoryAxis/>
+      <VictoryAxis dependentAxis/>
+      <VictoryLine
+        style={{ data: { stroke: "orange" }}}
+        y={(data) => Math.sin(2 * Math.PI * data.x)}
+      />
+      <VictoryScatter
+        y={(data) => Math.sin(2 * Math.PI * data.x)}
+        samples={25}
+        size={5}
+        style={{ data: { fill: "tomato" }}}
+      />
+    </VictoryChart>
+  </div>
 ```
 
 

--- a/src/screens/guides/components/theme-park/demo-component.js
+++ b/src/screens/guides/components/theme-park/demo-component.js
@@ -13,83 +13,65 @@ const scatterData = times(20, (i) => ({
 const toInteger = (number) => parseInt(number).toString();
 
 const DemoComponent = ({ theme }) => {
-  const positions = [
-    {transform: "translate(0, -15)"},
-    {transform: "translate(180, -40)"},
-    {transform: "translate(-10, 140)"},
-    {transform: "translate(180, 140)"}
-  ];
+  const style = { parent: { maxWidth: "50%" } };
   return (
-    <svg viewBox="0 0 400 400" role="img" aria-labelledby="title desc"
-      style={{height: "auto", width: "100%"}}
-    >
-      <g transform={positions[0].transform}>
-        <VictoryPie
-          theme={theme}
-          standalone={false}
-          style={{labels: {padding: 10}}}
-          height={200}
-          width={200}
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      <VictoryPie
+        theme={theme}
+        style={{ parent: style.parent, labels: { padding: 10 } }}
+        height={300}
+        width={300}
+      />
+      <VictoryChart theme={theme} height={300} width={300} style={style}>
+        <VictoryAxis tickCount={3} tickFormat={toInteger}/>
+        <VictoryAxis tickCount={4} dependentAxis/>
+        <VictoryScatter
+          size={2}
+          data={scatterData}
         />
-      </g>
+      </VictoryChart>
 
-      <g transform={positions[1].transform}>
-        <VictoryChart theme={theme} standalone={false} height={250} width={250}>
-          <VictoryAxis tickCount={3} tickFormat={toInteger}/>
-          <VictoryAxis tickCount={4} dependentAxis/>
-          <VictoryScatter
-            size={2}
-            data={scatterData}
+      <VictoryChart theme={theme} height={300} width={300} style={style}>
+        <VictoryAxis tickCount={4} domain={[0, 3]} tickFormat={toInteger}/>
+        <VictoryAxis tickCount={4} dependentAxis domain={[0, 10]}/>
+        <VictoryLine
+          y={(data) => data.x * data.x}
+        />
+      </VictoryChart>
+
+      <VictoryChart style={style}
+        theme={theme}
+        height={300}
+        width={300}
+        domainPadding={{x: 50}}
+      >
+        <VictoryAxis tickValues={["A", "B", "C"]}/>
+        <VictoryAxis tickCount={3} dependentAxis/>
+        <VictoryStack>
+          <VictoryBar
+            data={[
+              {x: "apples", y: 1},
+              {x: "bananas", y: 3},
+              {x: "oranges", y: 3}
+            ]}
           />
-        </VictoryChart>
-      </g>
-
-      <g transform={positions[2].transform}>
-        <VictoryChart theme={theme} standalone={false} height={250} width={250}>
-          <VictoryAxis tickCount={4} domain={[0, 3]} tickFormat={toInteger}/>
-          <VictoryAxis tickCount={4} dependentAxis domain={[0, 10]}/>
-          <VictoryLine
-            y={(data) => data.x * data.x}
+          <VictoryBar
+            data={[
+              {x: "apples", y: 2},
+              {x: "bananas", y: 1},
+              {x: "oranges", y: 3}
+            ]}
           />
-        </VictoryChart>
-      </g>
-
-      <g transform={positions[3].transform}>
-        <VictoryChart
-          standalone={false}
-          theme={theme}
-          height={250}
-          width={250}
-          domainPadding={{x: 50}}
-        >
-          <VictoryAxis tickValues={["A", "B", "C"]}/>
-          <VictoryAxis tickCount={3} dependentAxis/>
-          <VictoryStack>
-            <VictoryBar
-              data={[
-                {x: "apples", y: 1},
-                {x: "bananas", y: 3},
-                {x: "oranges", y: 3}
-              ]}
-            />
-            <VictoryBar
-              data={[
-                {x: "apples", y: 2},
-                {x: "bananas", y: 1},
-                {x: "oranges", y: 3}
-              ]}
-            />
-            <VictoryBar
-              data={[
-                {x: "apples", y: 3},
-                {x: "bananas", y: 1},
-                {x: "oranges", y: 1}
-              ]}
-            />
-          </VictoryStack>
-        </VictoryChart>
-      </g>
-    </svg>
+          <VictoryBar
+            data={[
+              {x: "apples", y: 3},
+              {x: "bananas", y: 1},
+              {x: "oranges", y: 1}
+            ]}
+          />
+        </VictoryStack>
+      </VictoryChart>
+    </div>
   );
 };
 

--- a/src/screens/guides/components/theme-park/index.js
+++ b/src/screens/guides/components/theme-park/index.js
@@ -66,7 +66,7 @@ class ThemePark extends React.Component {
 
   render() {
     return (
-      <div className="Recipe">
+      <div>
         <h1>Themes</h1>
         <p>
           Try out the Victory themes and make your own.

--- a/src/screens/guides/components/theme-park/index.js
+++ b/src/screens/guides/components/theme-park/index.js
@@ -77,7 +77,7 @@ class ThemePark extends React.Component {
         </p>
         {this.renderMenu()}
         <PureRender themeName={this.state.themeName} editted={this.state.editted}>
-          <pre className="u-noMarginTop u-noPadding">
+          <pre className="Recipe Markdown">
             <div className="Interactive" onKeyPress={this.handleUserEdit.bind(this)}>
               <Playground
                 codeText={this.getCodeText()}

--- a/src/stores/sidebar-content.js
+++ b/src/stores/sidebar-content.js
@@ -59,6 +59,13 @@ const sidebarContent = [
   },
   {
     id: id(),
+    "text": "",
+    children: [
+      subHeading(docItems, "introduction")
+    ]
+  },
+  {
+    id: id(),
     text: "Guides",
     children: [
       subHeading(guideItems)

--- a/src/stores/sidebar-content.js
+++ b/src/stores/sidebar-content.js
@@ -59,9 +59,9 @@ const sidebarContent = [
   },
   {
     id: id(),
-    "text": "",
+    "text": "Support",
     children: [
-      subHeading(docItems, "introduction")
+      subHeading(docItems, "support")
     ]
   },
   {

--- a/src/styles/components/gallery.css
+++ b/src/styles/components/gallery.css
@@ -24,7 +24,7 @@
   padding: var(--gutter-small);
 }
 
-.Gallery-item .Preview svg {
+.Gallery-item .Preview .VictoryContainer svg {
   height: 100% !important;
 }
 

--- a/src/styles/components/playground.css
+++ b/src/styles/components/playground.css
@@ -23,18 +23,17 @@
 }
 
 .Interactive {
+  background-color: color(var(--codeMirrorbg) a(50%));
   position: relative;
-  margin: var(--gutter) 0 0;
   width: 100%;
 }
 
 .Interactive .playground {
-  background-color: var(--codeMirrorbg);
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
+  flex-wrap: none;
   padding: 0;
 
   @media (--small-viewport) {
@@ -43,18 +42,16 @@
 }
 
 .Interactive .playgroundCode {
-  background-color: var(--lighterSand);
   flex: auto;
   order: 2;
-  margin: 0;
-  padding: 0;
+  margin: 0 0 var(--gutter-small) 0;
   position: relative;
 }
 
 .Interactive .playgroundCode:before,
 .Interactive .playgroundPreview:before {
   position: absolute;
-  bottom: 100%;
+  top: 0;
   left: 0;
   right: 0;
 
@@ -63,22 +60,23 @@
   font-size: 0.9em;
   line-height: 1;
   letter-spacing: 0.15em;
-  padding: 0.75em 0.5em;
   text-align: center;
   text-transform: uppercase;
 }
 
 .Interactive .playgroundCode:before {
   content: "Editable Source";
-
-  background-color: color(var(--codeMirrorbgDim) a(50%));
+  padding: 1.25em 0.5em;
+  top: inherit;
+  bottom: 100%;
 }
 
 .Interactive .playgroundStage {
   background-color: var(--codeMirrorbgDim);
   overflow: auto;
   padding: var(--gutter-small) var(--gutter);
-  width: 100%;
+  width: 80%;
+  margin: 0 auto;
   height: 100%;
   resize: both;
   transition: background-color 195ms ease-in;
@@ -95,17 +93,15 @@
   display: flex;
   flex: 1 1 var(--initialHeight);
   justify-content: center;
-  margin: 0 0 var(--gutter) 0;
   order: 1;
-  padding: 0 var(--gutter-small);
   position: relative;
   text-align: center;
 }
 
 .Interactive .playgroundPreview:before {
   content: "Live Preview";
+  padding: 1.25em 0.5em;
 
-  background-color: color(var(--codeMirrorbg) a(50%));
 }
 
 .Interactive .playgroundPreview > div:first-child {
@@ -114,23 +110,24 @@
 }
 
 .Interactive .previewArea {
+  background-color: white;
   height: 100%;
   min-height: calc(var(--initialHeight)* 0.5);
-  width: auto;
+  width: 80%;
+  margin: 3em auto;
 }
 
 .Interactive .previewArea > div:first-child {
-  height: 100%;
-  margin: 0 auto;
-  width: 100%;
+  height: inherit;
+  max-height: 100%;
+  width: auto;
 }
 
-.Interactive .playgroundPreview svg {
-  height: inherit !important; /* override default Victory inline styles */
+.Interactive .playgroundPreview .VictoryContainer svg {
   margin: 0 auto;
   max-height: calc(var(--initialHeight) - 40px);
+  max-width: 100%;
   width: auto !important; /* override default Victory inline styles */
-  max-width: 80%;
 }
 
 .Interactive .playgroundError {

--- a/static-routes.js
+++ b/static-routes.js
@@ -45,6 +45,7 @@ module.exports = [
   "/gallery/custom-tooltip-labels",
   "/gallery/interpolation",
   "/gallery/horizontal-grouped-bars",
+  "/gallery/multiple-dependent-axes",
   "/gallery/multipoint-tooltip-labels",
   "/gallery/radar-chart",
   "/gallery/polar-cardioid",

--- a/static-routes.js
+++ b/static-routes.js
@@ -49,6 +49,7 @@ module.exports = [
   "/gallery/multipoint-tooltip-labels",
   "/gallery/radar-chart",
   "/gallery/polar-cardioid",
+  "/gallery/rainbow-gradient",
   "/gallery/stacked-bars-central-axis",
   "/gallery/stacked-grouped-bars",
   "/gallery/stacked-polar-bars",

--- a/static-routes.js
+++ b/static-routes.js
@@ -4,6 +4,7 @@ module.exports = [
   "/",
   "/about",
   "/docs",
+  "/docs/faq",
   "/docs/native",
   "/docs/common-props",
   "/docs/create-container",

--- a/test/func/spec/sidebar.spec.js
+++ b/test/func/spec/sidebar.spec.js
@@ -36,7 +36,7 @@ describe("Sidebar", function () {
   it("should render all headings", function () {
     return navigateToPageWithSidebar()
       .getText(selectors.sidebarHeading).then(function (res) {
-        expect(res).to.eql(["Introduction", "Guides", "Documentation"]);
+        expect(res).to.eql(["Introduction", "Support", "Guides", "Documentation"]);
       })
       .getText(selectors.sidebarSubheading).then(function (res) {
         expect(res).to.eql(["CHART", "CORE", "MORE"]);


### PR DESCRIPTION
Resolves #380 

Questions:
 
- Should the FAQ page live at `/docs/faq` or `/faq`?
- Where should the FAQ link be in the Sidebar list? The "Introduction" section doesn’t open up the subheadings like the other sections do, so it’s floating separately on its own for the moment. 

![screen shot 2017-09-05 at 5 49 30 pm](https://user-images.githubusercontent.com/768965/30089589-b025c392-9262-11e7-9b77-8a5b9bf5895a.png)

FAQ with open subheadings:  

![screen shot 2017-09-05 at 5 49 33 pm](https://user-images.githubusercontent.com/768965/30089592-b92c4f1a-9262-11e7-8668-57bb8baf1451.png)

FAQ search:

![screen shot 2017-09-05 at 5 49 39 pm](https://user-images.githubusercontent.com/768965/30089601-c1ffb424-9262-11e7-92d3-3554e329e0f8.png)

