### PR TITLE
Fix broken FAQs link

### DIFF
--- a/src/screens/docs/components/index.md
+++ b/src/screens/docs/components/index.md
@@ -424,5 +424,5 @@ For more information about Victory and its components, check out the docs - see 
 
 [our guides]: https://formidable.com/open-source/victory/guides
 [Gallery]: https://formidable.com/open-source/victory/gallery
-[FAQs]: https://formidable.com/open-source/victory/faq
+[FAQs]: https://formidable.com/open-source/victory/docs/faq
 [Check out the native version of this getting started tutorial]: https://formidable.com/open-source/victory/docs/native


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory-docs/issues/449

The old link was returning a 404. Even though it's quite a nice 404 page, this is a nicer experience :)