### PR TITLE
Fix path prefix gallery

### DIFF
--- a/src/pages/gallery/index.js
+++ b/src/pages/gallery/index.js
@@ -113,9 +113,9 @@ class Gallery extends React.Component {
 
   render() {
     const { location } = this.props;
-    const prefix = "/gallery/";
-    const slug = location && location.pathname.slice(prefix.length, location.pathname.length);
-
+    const chunks = location.pathname.split("/");
+    const prefixIndex = chunks.indexOf("gallery");
+    const slug = chunks[prefixIndex + 1];
     const activePage = slug
       ? this.renderPlayground(slug)
       : this.renderPreviews(configGallery);

--- a/src/partials/sidebar/index.js
+++ b/src/partials/sidebar/index.js
@@ -93,10 +93,9 @@ class Sidebar extends React.Component {
       // If link is currently active and not under the Introduction section,
       // then display its table of contents underneath it
       const active =
-        category !== "introduction" && location.pathname === link.fields.slug
+        category !== "introduction" && !isEmpty(location.pathname.match(link.fields.slug))
           ? true
           : this.state.filterTerm !== "";
-
       const headings = this.state.filterTerm !== "" ?
         this.getMatchTree(link, this.state.filterTerm) : link.headings;
 


### PR DESCRIPTION
fixes gallery rendering and sidebar active state. Outstanding issue: refreshing on individual gallery example pages. Pages are not being pre-built