### PR TITLE
Removes padding on extra small screens and adds horizontal scrolling

### DIFF
--- a/src/styles/components/playground.css
+++ b/src/styles/components/playground.css
@@ -15,7 +15,12 @@
 }
 
 .Markdown .pre {
-  padding-top: 0;
+  padding: 0 0 2rem 0;
+}
+@media (--medium-viewport) {
+  .Markdown .pre {
+    padding: 0 var(--gutter) 2rem var(--gutter);
+  }
 }
 
 .playgroundsMaxHeight .Interactive .playgroundStage,
@@ -117,6 +122,7 @@
   min-height: calc(var(--initialHeight)* 0.5);
   width: 80%;
   margin: 3em auto;
+  overflow-x: auto;
 }
 
 .Interactive .previewArea > div:first-child {


### PR DESCRIPTION
I browsed through the docs on my mobile phone and found the playground quite hard to use. One simple change that would improve the experience a lot, would be to remove that unnecessary padding on the sides and allow it to be scrollable. It doesn't help a ton with the code editor part, but you probably don't want to play with it too much on the mobile anyway.

![victory charts mobile](https://user-images.githubusercontent.com/1062898/34463183-30b78642-ee54-11e7-947d-d21eb2812546.jpg)

The only issues I can think of is that overflow-x would somehow influence the interactions(?) but it was working fine for me. Here is how it looks/works:
![victorymobilepr](https://user-images.githubusercontent.com/1062898/34463201-92956ab4-ee54-11e7-9d87-61368a8d233c.gif)

Thanks