### PR TITLE
Fix small typo in VictoryLine's description of the animate prop.

### DIFF
--- a/src/pages/docs/victory-line.md
+++ b/src/pages/docs/victory-line.md
@@ -36,7 +36,7 @@ VictoryLine renders a dataset as a single line. VictoryLine can be composed with
 
 `type: boolean || object`
 
-`VictoryLine` uses the standard `animate` prop. [Read about it herhttps://formidable.com/open-source/victorye](/docs/common-props#animate)
+`VictoryLine` uses the standard `animate` prop. [Read about it here](https://formidable.com/open-source/victory/docs/common-props#animate)
 
 See the [Animations Guide][] for more detail on animations and transitions
 


### PR DESCRIPTION
This PR:
- Fixes one small typo I noticed while going through the `VictoryLine` docs yesterday. The link for the `animate` prop on `VictoryLine` is incorrectly formatted in Markdown in production.
<img width="679" alt="screen shot 2018-04-16 at 9 30 15 am" src="https://user-images.githubusercontent.com/19421190/38822628-e05602a2-4158-11e8-90c6-b157354ba350.png">

This PR changes it to match how the `animate` prop is documented on other pages, i.e. `VictoryBar`. Developing locally, this looks like:
<img width="686" alt="screen shot 2018-04-16 at 9 31 59 am" src="https://user-images.githubusercontent.com/19421190/38822695-10ca229c-4159-11e8-9fff-907612aafa74.png">
