### PR TITLE
Fix breaking typo in victory-scatter events

### DIFF
--- a/src/pages/docs/victory-scatter.md
+++ b/src/pages/docs/victory-scatter.md
@@ -211,7 +211,7 @@ See the [Events Guide][] for more information on defining events.
             }, {
               target: "labels",
               mutation: (props) => {
-                return props.text === "clicked ?
+                return props.text === "clicked" ?
                   null : { text: "clicked" };
               }
             }


### PR DESCRIPTION
This fixes the typo in VictoryScatter events section that's broken:

<img width="807" alt="screen shot 2018-05-14 at 11 33 34" src="https://user-images.githubusercontent.com/882253/40004019-28f56c14-576b-11e8-9c6d-6860754623f0.png">

http://formidable.com/open-source/victory/docs/victory-scatter/