### PR TITLE
revert to older component-playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3245,14 +3245,52 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "component-playground": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/component-playground/-/component-playground-3.1.2.tgz",
-      "integrity": "sha512-0xiN2NIXiSZ4ycbW93CdAGmkyZcyW7gxPTtWVx/hQMpihjB1fZ+rzzjLOR8C3QMc8Hm7StTCmEYAJTbZtkfU8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/component-playground/-/component-playground-2.1.0.tgz",
+      "integrity": "sha512-bas5ABAgrfCLDRlNnlkdF+RJ3a8y1K5ShSml+gibGSxURF9Gh/gl/bVdVT0k+lE0sApvmMVboc/aoa6u3cUuwA==",
       "requires": {
+        "babel-cli": "6.26.0",
+        "babel-core": "6.26.0",
+        "babel-loader": "6.4.1",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-react": "6.24.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-preset-stage-1": "6.24.1",
         "babel-standalone": "6.26.0",
         "codemirror": "5.38.0",
         "prop-types": "15.6.1",
-        "react-codemirror2": "2.0.2"
+        "react": "15.6.2",
+        "react-addons-test-utils": "15.6.2",
+        "react-codemirror": "1.0.0",
+        "react-dom": "15.6.2",
+        "rimraf": "2.6.2",
+        "webpack": "1.15.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "requires": {
+            "create-react-class": "15.6.3",
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
       }
     },
     "component-props": {
@@ -12864,6 +12902,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -17669,10 +17712,23 @@
         "prop-types": "15.6.1"
       }
     },
-    "react-codemirror2": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-2.0.2.tgz",
-      "integrity": "sha512-wzsfxnvgGBU3Dftp7G36yjWThm/tN+hzRVZ14sfsiUtTx/od0kmIm9aHU4qavuLKYtN868mCZ7/BOHOVGS03GA=="
+    "react-addons-test-utils": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
+      "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY="
+    },
+    "react-codemirror": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-codemirror/-/react-codemirror-1.0.0.tgz",
+      "integrity": "sha1-kUZ7U7H12A2Rai/QtMetuFqQAbo=",
+      "requires": {
+        "classnames": "2.2.5",
+        "codemirror": "5.38.0",
+        "create-react-class": "15.6.3",
+        "lodash.debounce": "4.0.8",
+        "lodash.isequal": "4.5.0",
+        "prop-types": "15.6.1"
+      }
     },
     "react-deep-force-update": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-docs#readme",
   "dependencies": {
-    "component-playground": "^3.1.0",
+    "component-playground": "^2.1.0",
     "formidable-landers": "^8.1.8",
     "fuse.js": "^3.2.0",
     "gatsby": "^1.9.261",


### PR DESCRIPTION
`component-playground@^3.0.0` is relying on a version of codemirror / react-codemirror that causes a build error for gatsby

```
16 | // Kludges for bugs and behavior differences that can't be feature
  17 | // detected are enabled based on userAgent etc sniffing.
> 18 | var userAgent = navigator.userAgent;
     | ^
  19 | var platform = navigator.platform;
  20 |
  21 | var gecko = /gecko\/\d/i.test(userAgent);


  WebpackError: navigator is not defined

  - codemirror.js:18
    ~/codemirror/lib/codemirror.js:18:1

  - codemirror.js:11 userAgent
    ~/codemirror/lib/codemirror.js:11:1

  - codemirror.js:14 Object.<anonymous>
    ~/codemirror/lib/codemirror.js:14:2

  - index.js:21 Object.<anonymous>
    ~/react-codemirror2/index.js:21:1

  - editor.js:17 Object.defineProperty.value
    ~/component-playground/lib/components/editor.js:17:1

  - playground.js:19 Object.<anonymous>
    ~/component-playground/lib/components/playground.js:19:1
```