### PR TITLE
smaller header on all pages other than home

### DIFF
--- a/src/partials/header.js
+++ b/src/partials/header.js
@@ -32,7 +32,7 @@ class VictoryHeader extends Component {
 
     return (
       <Header className={className} logoProject={victoryLogo}>
-        <div className="default" style={{ textAlign: "left", paddingBottom: 0 }}>
+        <div className="default" style={{ paddingBottom: 0 }}>
           {victoryLink}
           <Link to="/about/">About</Link>
           <Link to="/docs/">Docs</Link>

--- a/src/partials/header.js
+++ b/src/partials/header.js
@@ -9,19 +9,31 @@ import LOGO from "../../static/logotype-hero.svg";
 
 class VictoryHeader extends Component {
   render() {
-    const classes = this.props.home ? "victory isHome" : "victory";
+    const className = this.props.home ? undefined : "victory";
 
-    const victoryLogo = (
-      <Link
-        to="/"
-        style={{ display: "block", height: "50px" }}
-        dangerouslySetInnerHTML={{ __html: LOGO }}
-      />
-    );
+    const victoryLogo = this.props.home ?
+      (
+        <Link
+          to="/"
+          style={{ display: "block", height: "50px" }}
+          dangerouslySetInnerHTML={{ __html: LOGO }}
+        />
+      ) : undefined;
+
+    const victoryLink = this.props.home ?
+      undefined :
+      (
+        <Link
+          to="/"
+          style={{ height: "50px" }}
+          dangerouslySetInnerHTML={{ __html: LOGO }}
+        />
+      );
 
     return (
-      <Header className={classes} logoProject={victoryLogo}>
-        <div className="default" style={{ textAlign: "center" }}>
+      <Header className={className} logoProject={victoryLogo}>
+        <div className="default" style={{ textAlign: "left", paddingBottom: 0 }}>
+          {victoryLink}
           <Link to="/about/">About</Link>
           <Link to="/docs/">Docs</Link>
           <Link to="/docs/faq">FAQ</Link>

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -5,6 +5,9 @@
 .formidableHeader.victory .formidableHeader-container {
   margin-right: 3vw;
   margin-left: 3vw;
+  padding-top: 50px;
+  padding-bottom: 0px;
+  align-items: flex-start
 }
 
 .formidableHeader.victory .formidableHeader-by {


### PR DESCRIPTION
@paulathevalley I changed the victory header on pages other than the home page so that they look like this: 
<img width="1398" alt="screen shot 2018-06-24 at 9 33 49 pm" src="https://user-images.githubusercontent.com/3719995/41830524-6fc31bea-77f6-11e8-9e60-6048509eb35d.png">

The home screen still looks like 
<img width="1404" alt="screen shot 2018-06-24 at 9 34 01 pm" src="https://user-images.githubusercontent.com/3719995/41830546-98b63f82-77f6-11e8-9667-89d72db79f17.png">

I see this as a utilitarian and possibly temporary solution. I'm not sure how to make it look better without messing with `formidable-landers` but I would love suggestions and help.