### PR TITLE
smaller header

### DIFF
--- a/__tests__/pages/about/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/about/__snapshots__/index.test.js.snap
@@ -234,7 +234,7 @@ exports[`<About /> should render correctly. 1`] = `
     >
       <Footer
         className="victory"
-        theme="dark"
+        theme="light"
         trademark={
           <div
             className="default"
@@ -244,7 +244,7 @@ exports[`<About /> should render correctly. 1`] = `
         }
       >
         <footer
-          className="formidableFooter isDark victory"
+          className="formidableFooter isLight victory"
         >
           <div
             className="formidableFooter-container"

--- a/__tests__/pages/about/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/about/__snapshots__/index.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`<About /> should render correctly. 1`] = `
 <About>
-  <div>
+  <div
+    className="index-container"
+  >
     <article
       className="Article"
     >

--- a/__tests__/pages/gallery/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/gallery/__snapshots__/index.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`<Gallery /> should render correctly. 1`] = `
 <About>
-  <div>
+  <div
+    className="index-container"
+  >
     <article
       className="Article"
     >

--- a/__tests__/pages/gallery/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/gallery/__snapshots__/index.test.js.snap
@@ -234,7 +234,7 @@ exports[`<Gallery /> should render correctly. 1`] = `
     >
       <Footer
         className="victory"
-        theme="dark"
+        theme="light"
         trademark={
           <div
             className="default"
@@ -244,7 +244,7 @@ exports[`<Gallery /> should render correctly. 1`] = `
         }
       >
         <footer
-          className="formidableFooter isDark victory"
+          className="formidableFooter isLight victory"
         >
           <div
             className="formidableFooter-container"

--- a/src/layouts/with-sidebar.js
+++ b/src/layouts/with-sidebar.js
@@ -31,7 +31,7 @@ class LayoutWithSidebar extends React.Component {
     }
 
     return (
-      <div className="u-fullHeight">
+      <div className="Page-wrapper u-fullHeight">
         <Header home={false} />
         <main className="Page">
           <div className="Page-sidebar">

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -7,7 +7,7 @@ import Showcase from "../../partials/about/showcase";
 class About extends React.Component {
   render() {
     return (
-      <div>
+      <div className="index-container">
         <article className="Article">
           <h1 className="u-noMargin">
             Victory: Charting for React and React Native

--- a/src/pages/gallery/index.js
+++ b/src/pages/gallery/index.js
@@ -79,7 +79,7 @@ class Gallery extends React.Component {
     });
 
     return (
-      <div>
+      <div className="index-container">
         <article className="Article Article--noBottom">
           <h1 className="u-noMargin">Gallery</h1>
           <div className="Gallery">{previews}</div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,11 +7,6 @@ import Hero from "../partials/home/hero";
 
 class Index extends React.Component {
   render() {
-    const trademark = (
-      <div className="default">
-        Victory is a trademark of Formidable Labs, Inc.
-      </div>
-    );
     return (
       <div className="index-container">
         <section className="Home playgroundsMaxHeight">
@@ -38,7 +33,7 @@ class Index extends React.Component {
             </p>
           </div>
         </section>
-        <Footer trademark={trademark} />
+        <Footer />
       </div>
     );
   }

--- a/src/partials/footer.js
+++ b/src/partials/footer.js
@@ -11,7 +11,7 @@ class VictoryFooter extends React.Component {
       </div>
     );
 
-    return <Footer className="victory" trademark={trademark} theme="dark" />;
+    return <Footer className="victory" trademark={trademark} theme="light" />;
   }
 }
 

--- a/src/partials/header.js
+++ b/src/partials/header.js
@@ -9,8 +9,6 @@ import LOGO from "../../static/logotype-hero.svg";
 
 class VictoryHeader extends Component {
   render() {
-    const classes = this.props.home ? "victory isHome" : "victory";
-
     const victoryLogo = (
       <Link
         to="/"
@@ -20,8 +18,9 @@ class VictoryHeader extends Component {
     );
 
     return (
-      <Header className={classes} logoProject={victoryLogo}>
-        <div className="default" style={{ textAlign: "center" }}>
+      <Header className={"victory"}>
+        <div className="default" style={{ paddingBottom: 0 }}>
+          {victoryLogo}
           <Link to="/about/">About</Link>
           <Link to="/docs/">Docs</Link>
           <Link to="/docs/faq">FAQ</Link>

--- a/src/partials/header.js
+++ b/src/partials/header.js
@@ -18,7 +18,7 @@ class VictoryHeader extends Component {
     );
 
     return (
-      <Header className={"victory"}>
+      <Header className={"victory"} theme="light">
         <div className="default" style={{ paddingBottom: 0 }}>
           {victoryLogo}
           <Link to="/about/">About</Link>

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -8,6 +8,9 @@ html {
 }
 
 .index-container {
+  display: flex;
+  flex-direction: column;
+
   font-size: 16px;
 }
 

--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -7,6 +7,5 @@
 .formidableFooter.victory .formidableFooter-container {
   margin-right: 3vw;
   margin-left: 3vw;
-  margin-bottom: 10;
   background-color: var(--lightestSand);
 }

--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -7,5 +7,7 @@
 .formidableFooter.victory .formidableFooter-container {
   margin-right: 3vw;
   margin-left: 3vw;
+  margin-top: 20px;
+  margin-bottom: 20px;
   background-color: var(--lightestSand);
 }

--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -1,9 +1,12 @@
 .formidableFooter.victory {
   margin: 0;
   padding: 0;
+  background-color: var(--lightestSand);
 }
 
 .formidableFooter.victory .formidableFooter-container {
   margin-right: 3vw;
   margin-left: 3vw;
+  margin-bottom: 10;
+  background-color: var(--lightestSand);
 }

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -5,6 +5,8 @@
 .formidableHeader.victory .formidableHeader-container {
   margin-right: 3vw;
   margin-left: 3vw;
+  padding-top: 50px;
+  padding-bottom: 0px;
 }
 
 .formidableHeader.victory .formidableHeader-by {

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -1,12 +1,16 @@
 .formidableHeader.victory {
   padding: 0;
+  background-color: var(--lightestSand);
+  border-bottom: 1px solid var(--darkSand);
 }
 
 .formidableHeader.victory .formidableHeader-container {
   margin-right: 3vw;
   margin-left: 3vw;
-  padding-top: 50px;
-  padding-bottom: 0px;
+  padding-top: 48px;
+  padding-bottom: 2px;
+  background-color: var(--lightestSand);
+
 }
 
 .formidableHeader.victory .formidableHeader-by {

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -1,8 +1,18 @@
 /*
-* .Page
-*   .Page-sidebar
-*   .Page-content
+* .Page-wrapper
+*   Header
+*   .Page
+*     .Page-sidebar
+*     .Page-content
 */
+
+@media (--medium-viewport) {
+  .Page-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+}
 
 .Page {
   display: flex;
@@ -15,7 +25,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    height: calc(100% - 190px);
+    flex: 1;
   }
 }
 

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -15,7 +15,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    height: calc(100% - 160px);
+    height: calc(100% - 190px);
   }
 }
 


### PR DESCRIPTION
@paulathevalley here's another option that just drastically cuts down the height of the header on every page: 
<img width="1395" alt="screen shot 2018-06-24 at 9 47 39 pm" src="https://user-images.githubusercontent.com/3719995/41830895-827c510a-77f8-11e8-8ec4-0d48327dd761.png">

Does this seem better to you?