### PR TITLE
Fixed typo in `VictoryAxis` page under `gridComponent` prop section

### DIFF
--- a/src/pages/docs/victory-axis.md
+++ b/src/pages/docs/victory-axis.md
@@ -153,7 +153,7 @@ well for labels that are approximately evenly spaced.
 
 `type: element`
 
-The `gridComponent` prop takes a component instance which will be responsible for rendering a grid element. The new element created from the passed `gridComponent` will be provided with the following props calculated by `VictoryAxis`: `x1`, `y1`, `x2`, `y2`, `tick`, `style` and `events`. Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within the custom component itself. If a `gridComponent` is not provided, `VictoryAxis` will use its default [LinSegmente component][].
+The `gridComponent` prop takes a component instance which will be responsible for rendering a grid element. The new element created from the passed `gridComponent` will be provided with the following props calculated by `VictoryAxis`: `x1`, `y1`, `x2`, `y2`, `tick`, `style` and `events`. Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within the custom component itself. If a `gridComponent` is not provided, `VictoryAxis` will use its default [LineSegment component][].
 
 *default:* `gridComponent={<LineSegment type={"grid"}/>}`
 


### PR DESCRIPTION
"LinSegmente" -> "LineSegment"