### PR TITLE
Eliminate duplicate orientation prop

### DIFF
--- a/src/content/docs/victory-legend.md
+++ b/src/content/docs/victory-legend.md
@@ -309,7 +309,6 @@ The `rowGutter` prop defines the number of pixels between legend rows. This prop
 ```playground
 <VictoryLegend x={125} y={50}
   orientation="vertical"
-  orientation="vertical"
   gutter={20}
   rowGutter={{ top: 0, bottom: 10 }}
   style={{ border: { stroke: "black" } }}


### PR DESCRIPTION
Just noticed that the `orientation` prop is included twice on one of the vertical legend examples.

Thank you for an awesome library!