### PR TITLE
Fix typo with VictoryScatter's animate prop

### DIFF
--- a/src/content/docs/victory-scatter.md
+++ b/src/content/docs/victory-scatter.md
@@ -35,7 +35,7 @@ VictoryScatter renders a dataset as a series of points. VictoryScatter can be co
 
 `type: boolean || object`
 
-`VictoryScatter` uses the standard `animate` prop. [Read about it herhttps://formidable.com/open-source/victorye](/docs/common-props#animate)
+`VictoryScatter` uses the standard `animate` prop. [Read about it in detail here](https://formidable.com/open-source/victory/docs/common-props#animate)
 
 See the [Animations Guide][] for more detail on animations and transitions
 


### PR DESCRIPTION
Fixes #584 

I changed "Read about it here" to "Read about it in detail here" to match similar props on this page.