### PR TITLE
Change relative links to absolute in faq.md

### DIFF
--- a/src/content/faq/faq.md
+++ b/src/content/faq/faq.md
@@ -197,7 +197,7 @@ When no axes are supplied to `VictoryChart` it will render pair of default axes.
 
 ### Can I make a chart with multiple dependent axes?
 
-`VictoryChart` will render any number of axes, but all children rendered by `VictoryChart` will be forced to use the same domain. To create a single chart with the appearance of several different domains, you can either compose components manually without the aid of `VictoryChart`, as described in [this guide](/guides/custom-charts), or normalize all of your data, and re-scale your axis tick labels to give the appearance of separate domains as in [this example](/gallery/multiple-dependent-axes).
+`VictoryChart` will render any number of axes, but all children rendered by `VictoryChart` will be forced to use the same domain. To create a single chart with the appearance of several different domains, you can either compose components manually without the aid of `VictoryChart`, as described in [this guide](https://formidable.com/open-source/victory/guides/custom-charts), or normalize all of your data, and re-scale your axis tick labels to give the appearance of separate domains as in [this example](https://formidable.com/open-source/victory/gallery/multiple-dependent-axes).
 
 ### How can I change the position of my axis?
 


### PR DESCRIPTION
```
fix #631
Change relative links in the "Can I make a chart with
multiple dependent axes?" section to absolute links,
by prepending the website url
(https://formidable.com/open-source/victory/).
```

The relative links don't work under certain circumstances (see the issue #631).

In `faq.md` other links are absolute, so I guess it makes sense to change these relative links to absolute as well, so they always work, and for consistency.