### PR TITLE
Update sidebar nav

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -33,9 +33,9 @@ const GitHubIconContainer = styled.div`
   margin-bottom: 2.3rem;
 `;
 
-const About = ({ location }) => {
+const About = ({ location, sidebarContent }) => {
   return (
-    <Page location={location}>
+    <Page sidebarContent={sidebarContent} location={location}>
       <PageHeader>Victory: Charting for React and React Native</PageHeader>
       <GitHubIconContainer>
         {/*
@@ -115,7 +115,8 @@ const About = ({ location }) => {
 };
 
 About.propTypes = {
-  location: PropTypes.object
+  location: PropTypes.object,
+  sidebarContent: PropTypes.array
 };
 
 export default withRouteData(About);

--- a/src/pages/docs-template.js
+++ b/src/pages/docs-template.js
@@ -12,12 +12,7 @@ class DocsTemplate extends React.Component {
     const { content, data } = doc;
     const { title, scope } = data;
     return (
-      <Page
-        withSidebar
-        sidebarContent={sidebarContent}
-        sidebarContent={sidebarContent}
-        location={location}
-      >
+      <Page withSidebar sidebarContent={sidebarContent} location={location}>
         <Helmet>
           <title>{`${config.siteTitle} | ${title}`}</title>
           <meta name="description" content={config.siteDescription} />

--- a/src/pages/docs-template.js
+++ b/src/pages/docs-template.js
@@ -12,7 +12,12 @@ class DocsTemplate extends React.Component {
     const { content, data } = doc;
     const { title, scope } = data;
     return (
-      <Page withSidebar sidebarContent={sidebarContent} location={location}>
+      <Page
+        withSidebar
+        sidebarContent={sidebarContent}
+        sidebarContent={sidebarContent}
+        location={location}
+      >
         <Helmet>
           <title>{`${config.siteTitle} | ${title}`}</title>
           <meta name="description" content={config.siteDescription} />

--- a/src/pages/gallery.js
+++ b/src/pages/gallery.js
@@ -51,7 +51,7 @@ const Divider = styled.hr`
   margin: 3rem 0;
 `;
 
-const Gallery = ({ gallery, location }) => {
+const Gallery = ({ gallery, location, sidebarContent }) => {
   const parseRaw = str => {
     const playground = "playground_norender";
     const start = str.indexOf(playground) + playground.length;
@@ -89,7 +89,7 @@ const Gallery = ({ gallery, location }) => {
   ));
 
   return (
-    <Page location={location}>
+    <Page sidebarContent={sidebarContent} location={location}>
       <PageHeader>Victory Gallery</PageHeader>
       <p>
         Here are some examples to help you get started. Each example below links
@@ -105,7 +105,8 @@ const Gallery = ({ gallery, location }) => {
 Gallery.propTypes = {
   data: PropTypes.object,
   gallery: PropTypes.array,
-  location: PropTypes.object
+  location: PropTypes.object,
+  sidebarContent: PropTypes.array
 };
 
 Gallery.defaultProps = {

--- a/src/partials/playground/playground-container.js
+++ b/src/partials/playground/playground-container.js
@@ -95,8 +95,6 @@ const PlaygroundContainer = styled.div`
       order: 1;
       position: relative;
       text-align: center;
-      width: 80%;
-      max-width: 50rem;
       margin: 0 auto;
       @media ${theme.mediaQuery.md} {	
         min-width: 40rem;
@@ -118,7 +116,6 @@ const PlaygroundContainer = styled.div`
       background-color: white;
       height: 100%;
       min-height: calc(${STAGE_HEIGHT}* 0.5);
-      width: 80%;
       margin: 3em auto;
       overflow-x: auto;
     }

--- a/src/partials/sidebar/components/introduction.js
+++ b/src/partials/sidebar/components/introduction.js
@@ -1,14 +1,85 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
+import styled, { css } from "styled-components";
+import { NavLink } from "react-router-dom";
 
 import { SidebarSectionHeading, SidebarSectionList } from "../styles";
 
+// Refactor these into shared styles
+const SidebarListItem = styled.li`
+  padding: 0;
+  margin: 0;
+  width: 100%;
+`;
+
+const SidebarListItemLinkStyle = css`
+  color: ${({ theme }) => theme.color.brown};
+  font-family: ${({ theme }) => theme.font.bold};
+  font-size: 1.4rem;
+  letter-spacing: 0.53px;
+  line-height: ${({ theme }) => theme.typography.lineHeight.sidebarHeading};
+  display: block;
+  padding: 0.4rem 0.7rem 0.3rem 3.4rem;
+  hyphens: auto;
+  &.is-active {
+    background-color: ${({ theme }) => theme.color.darkGray};
+  }
+`;
+
+const SidebarListItemLink = styled(NavLink)`
+  ${SidebarListItemLinkStyle}
+`;
+const SidebarListItemAnchorLink = styled.a`
+  ${SidebarListItemLinkStyle}
+`;
+
+const MobileSidebarLinks = styled.div`
+  @media ${({ theme }) => theme.mediaQuery.md} {
+    display: none;
+  }
+`;
+
+const renderMobileSidebarLinks = mobileLinks => {
+  return mobileLinks.map(link => {
+    const isExternal = link.slug.charAt(0) !== "/";
+    return (
+      <SidebarListItem key={link.slug}>
+        {isExternal ? (
+          <SidebarListItemAnchorLink href={link.slug} target="_blank">
+            {link.title}
+          </SidebarListItemAnchorLink>
+        ) : (
+          <SidebarListItemLink
+            to={`${link.slug}`}
+            activeClassName={"is-active"}
+            prefetch={"data"}
+          >
+            {link.title}
+          </SidebarListItemLink>
+        )}
+      </SidebarListItem>
+    );
+  });
+};
+
 const Introduction = ({ content }) => {
+  const mobileLinks = [
+    { slug: "/about", title: "About" },
+    { slug: "/docs/faqs", title: "Gallery" },
+    { slug: "https://spectrum.chat/victory", title: "Support" },
+    { slug: "https://github.com/FormidableLabs/victory", title: "Github" },
+    { slug: "/docs/faqs", title: "FAQs" }
+  ];
   return !isEmpty(content) ? (
     <>
       <SidebarSectionHeading>Introduction</SidebarSectionHeading>
-      <SidebarSectionList>{content}</SidebarSectionList>
+      <SidebarSectionList>
+        {content}
+        <MobileSidebarLinks>
+          {renderMobileSidebarLinks(mobileLinks)}
+        </MobileSidebarLinks>
+      </SidebarSectionList>
     </>
   ) : null;
 };

--- a/src/partials/sidebar/components/introduction.js
+++ b/src/partials/sidebar/components/introduction.js
@@ -1,38 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
-import styled, { css } from "styled-components";
-import { NavLink } from "react-router-dom";
+import styled from "styled-components";
 
-import { SidebarSectionHeading, SidebarSectionList } from "../styles";
-
-// Refactor these into shared styles
-const SidebarListItem = styled.li`
-  padding: 0;
-  margin: 0;
-  width: 100%;
-`;
-
-const SidebarListItemLinkStyle = css`
-  color: ${({ theme }) => theme.color.brown};
-  font-family: ${({ theme }) => theme.font.bold};
-  font-size: 1.4rem;
-  letter-spacing: 0.53px;
-  line-height: ${({ theme }) => theme.typography.lineHeight.sidebarHeading};
-  display: block;
-  padding: 0.4rem 0.7rem 0.3rem 3.4rem;
-  hyphens: auto;
-  &.is-active {
-    background-color: ${({ theme }) => theme.color.darkGray};
-  }
-`;
-
-const SidebarListItemLink = styled(NavLink)`
-  ${SidebarListItemLinkStyle}
-`;
-const SidebarListItemAnchorLink = styled.a`
-  ${SidebarListItemLinkStyle}
-`;
+import {
+  SidebarSectionHeading,
+  SidebarSectionList,
+  SidebarListItem,
+  SidebarListItemLink,
+  SidebarListItemAnchorLink
+} from "../styles";
 
 const MobileSidebarLinks = styled.div`
   @media ${({ theme }) => theme.mediaQuery.md} {
@@ -66,10 +43,10 @@ const renderMobileSidebarLinks = mobileLinks => {
 const Introduction = ({ content }) => {
   const mobileLinks = [
     { slug: "/about", title: "About" },
-    { slug: "/docs/faqs", title: "Gallery" },
+    { slug: "/gallery", title: "Gallery" },
     { slug: "https://spectrum.chat/victory", title: "Support" },
     { slug: "https://github.com/FormidableLabs/victory", title: "Github" },
-    { slug: "/docs/faqs", title: "FAQs" }
+    { slug: "/docs/faq", title: "FAQs" }
   ];
   return !isEmpty(content) ? (
     <>

--- a/src/partials/sidebar/index.js
+++ b/src/partials/sidebar/index.js
@@ -303,6 +303,7 @@ Sidebar.propTypes = {
   content: PropTypes.array,
   hideCloseButton: PropTypes.bool,
   location: PropTypes.shape({ pathname: PropTypes.string }),
+  mobileSidebarContent: PropTypes.array,
   onCloseClick: PropTypes.func
 };
 

--- a/src/partials/sidebar/index.js
+++ b/src/partials/sidebar/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { withRouteData } from "react-static";
-import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 import Fuse from "fuse.js";
 import { maxBy, findIndex, includes, last, isEmpty } from "lodash";
@@ -12,7 +11,11 @@ import Introduction from "./components/introduction";
 import Category from "./components/category";
 import SearchInput from "./components/search-input";
 import TableOfContents from "./components/table-of-contents";
-import { SidebarSectionHeading } from "./styles";
+import {
+  SidebarSectionHeading,
+  SidebarListItemLink,
+  SidebarListItem
+} from "./styles";
 
 // was gonna pass this but I'm leaning towards this being an internal detail since at the end of the day the proper
 // behavior is based on a bunch of magic strings for a non-configurable internal method
@@ -68,25 +71,6 @@ const VictoryLogo = styled(SVG)`
 
   > svg {
     width: 9.8rem;
-  }
-`;
-
-const SidebarListItem = styled.li`
-  padding: 0;
-  margin: 0;
-  width: 100%;
-`;
-const SidebarListItemLink = styled(NavLink)`
-  color: ${({ theme }) => theme.color.brown};
-  font-family: ${({ theme }) => theme.font.bold};
-  font-size: 1.4rem;
-  letter-spacing: 0.53px;
-  line-height: ${({ theme }) => theme.typography.lineHeight.sidebarHeading};
-  display: block;
-  padding: 0.4rem 0.7rem 0.3rem 3.4rem;
-  hyphens: auto;
-  &.is-active {
-    background-color: ${({ theme }) => theme.color.darkGray};
   }
 `;
 
@@ -303,7 +287,6 @@ Sidebar.propTypes = {
   content: PropTypes.array,
   hideCloseButton: PropTypes.bool,
   location: PropTypes.shape({ pathname: PropTypes.string }),
-  mobileSidebarContent: PropTypes.array,
   onCloseClick: PropTypes.func
 };
 

--- a/src/partials/sidebar/styles/index.js
+++ b/src/partials/sidebar/styles/index.js
@@ -1,5 +1,15 @@
 import SidebarSectionHeading from "./sidebar-section-heading";
 import SidebarSectionList from "./sidebar-section-subheading";
 import SidebarSectionSublist from "./sidebar-section-sublist";
+import SidebarListItem from "./sidebar-list-item";
+import SidebarListItemAnchorLink from "./sidebar-list-item-anchor-link";
+import SidebarListItemLink from "./sidebar-list-item-link";
 
-export { SidebarSectionHeading, SidebarSectionList, SidebarSectionSublist };
+export {
+  SidebarSectionHeading,
+  SidebarSectionList,
+  SidebarSectionSublist,
+  SidebarListItem,
+  SidebarListItemAnchorLink,
+  SidebarListItemLink
+};

--- a/src/partials/sidebar/styles/sidebar-list-item-anchor-link.js
+++ b/src/partials/sidebar/styles/sidebar-list-item-anchor-link.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import SidebarListItemLinkStyle from "./sidebar-list-item-link-style";
+
+const SidebarListItemAnchorLink = styled.a`
+  ${SidebarListItemLinkStyle}
+`;
+
+export default SidebarListItemAnchorLink;

--- a/src/partials/sidebar/styles/sidebar-list-item-link-style.js
+++ b/src/partials/sidebar/styles/sidebar-list-item-link-style.js
@@ -1,0 +1,17 @@
+import { css } from "styled-components";
+
+const SidebarListItemLinkStyle = css`
+  color: ${({ theme }) => theme.color.brown};
+  font-family: ${({ theme }) => theme.font.bold};
+  font-size: 1.4rem;
+  letter-spacing: 0.53px;
+  line-height: ${({ theme }) => theme.typography.lineHeight.sidebarHeading};
+  display: block;
+  padding: 0.4rem 0.7rem 0.3rem 3.4rem;
+  hyphens: auto;
+  &.is-active {
+    background-color: ${({ theme }) => theme.color.darkGray};
+  }
+`;
+
+export default SidebarListItemLinkStyle;

--- a/src/partials/sidebar/styles/sidebar-list-item-link.js
+++ b/src/partials/sidebar/styles/sidebar-list-item-link.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { NavLink } from "react-router-dom";
+import SidebarListItemLinkStyle from "./sidebar-list-item-link-style";
+
+const SidebarListItemLink = styled(NavLink)`
+  ${SidebarListItemLinkStyle}
+`;
+
+export default SidebarListItemLink;

--- a/src/partials/sidebar/styles/sidebar-list-item.js
+++ b/src/partials/sidebar/styles/sidebar-list-item.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const SidebarListItem = styled.li`
+  padding: 0;
+  margin: 0;
+  width: 100%;
+`;
+
+export default SidebarListItem;

--- a/static.config.js
+++ b/static.config.js
@@ -85,10 +85,9 @@ export default {
     const docSubroutes = commonProps.concat(introduction, trueDocs);
 
     const convertToSidebarArray = content => {
-      const { support, charts, containers, more } = content;
+      const { charts, containers, more } = content;
       return [
         ...introduction,
-        ...support,
         ...guides,
         commonPropsIntro,
         ...charts,
@@ -98,6 +97,7 @@ export default {
     };
 
     const sbContent = convertToSidebarArray(sidebarContent);
+
     return [
       {
         path: "/",
@@ -105,7 +105,10 @@ export default {
       },
       {
         path: "/about",
-        template: "src/pages/about"
+        template: "src/pages/about",
+        getData: async () => ({
+          sidebarContent: sbContent
+        })
       },
       {
         path: "/guides",

--- a/static.config.js
+++ b/static.config.js
@@ -155,6 +155,7 @@ export default {
         path: "/gallery",
         template: "src/pages/gallery",
         getData: async () => ({
+          sidebarContent: sbContent,
           gallery
         }),
         children: gallery.map(galleryItem => ({


### PR DESCRIPTION
I took a different approach then what was written in Notion. Basically every page has the same sidebar content, but the introduction section has routes that are hidden or shown (with css) based on if on a mobile device or not. Seemed like an easier way to get the same thing accomplished, but if you want me to go a different route I'm happy to explore it!

![Screen Shot 2020-02-03 at 11 33 25 AM](https://user-images.githubusercontent.com/923457/73680210-1bd2ac00-4679-11ea-9914-36d8b9cb3894.png)
![Screen Shot 2020-02-03 at 11 33 36 AM](https://user-images.githubusercontent.com/923457/73680214-1d03d900-4679-11ea-8ce9-6cb540ab578e.png)
