### PR TITLE
Adding animation to learn more scroll

### DIFF
--- a/src/partials/home/hero.js
+++ b/src/partials/home/hero.js
@@ -254,7 +254,9 @@ const Hero = ({
             </LinkItem>
           ))}
         </LinkContainer>
-        <LearnMore to="Features">LEARN MORE</LearnMore>
+        <LearnMore to="Features" smooth offset={-25} duration={500}>
+          LEARN MORE
+        </LearnMore>
       </LandingSectionContent>
     </HeroContainer>
     <HeroDemo />


### PR DESCRIPTION
Quick tweak to add animated scroll on 'learn more' in smaller viewport sizes of the landing page. 

To test: 
- make sure the 'learn more' button on the landing page is visible (mobile viewports only) and click it. See that it scrolls to 'features'.

![learn more scroll](https://user-images.githubusercontent.com/10720454/74690613-f24b7180-519c-11ea-815c-a38fc1128058.gif)
