### PR TITLE
Build fixes 

### DIFF
--- a/src/partials/sidebar/index.js
+++ b/src/partials/sidebar/index.js
@@ -143,11 +143,13 @@ const Sidebar = ({ className, content, location, onCloseClick }) => {
         filteredResults.filter(edge => {
           return edge.data && edge.data.type === sectionCategory.type;
         });
-      return (filteredByCategory[
-        [sectionCategory.category]
-      ] = filteredEdges.filter(edge =>
-        sectionCategory.category.includes(edge.data.category)
-      ));
+      return filteredEdges
+        ? (filteredByCategory[
+            [sectionCategory.category]
+          ] = filteredEdges.filter(edge =>
+            sectionCategory.category.includes(edge.data.category)
+          ))
+        : null;
     });
 
     const renderList = {};

--- a/static-config-helpers/md-data-transforms.js
+++ b/static-config-helpers/md-data-transforms.js
@@ -42,15 +42,15 @@ const orderByIdAndAddThemesEntry = items => {
 };
 
 const slugMutation = mdData => {
-  mdData.data.slug = _.kebabCase(mdData.data.title)
+  return (mdData.data.slug = _.kebabCase(mdData.data.title)
     .toLowerCase()
-    .trim();
+    .trim());
 };
 
 // for sidebar purposes, guide type and guide category are the same, but we'd rather have
 // a consistent shape at the component layer than need an additional check there
 const sidebarTypeMutation = mdData => {
-  mdData.data.type = mdData.data.category;
+  return (mdData.data.type = mdData.data.category);
 };
 
 // You could also be like `yarn add --dev immutability-helper` and use its syntax, but introducing it adds a
@@ -91,6 +91,7 @@ const sidebarTreeMutation = mdData => {
         ]
       });
     }
+    return null;
   }, []);
 };
 

--- a/static.config.js
+++ b/static.config.js
@@ -51,7 +51,6 @@ export default {
 
     // sure we *happen* to sort by id as part of data ingestion right now, but it shouldn't create unexpected behavior
     // if we ever change that.
-    const guidesIntro = _.find(guides, g => g.data.id === 0);
     const homeIntro = _.find(introduction, intro => intro.data.id === 0);
     // only one file here, use a selector-style fn if that ever changes
     const faqIntro = faq[0];
@@ -111,10 +110,10 @@ export default {
         })
       },
       {
-        path: "/guides",
-        template: "src/pages/docs-template",
+        path: "/guides", // guides shares the 404 template because its children have their own docs-template getting used and there is no parent page to render, removing this will cause you build issues
+        template: "src/pages/404",
         getData: async () => ({
-          doc: guidesIntro,
+          docs: trueDocs,
           sidebarContent: sbContent
         }),
         children: generateGuideRoutes(guides, { sidebarContent: sbContent })


### PR DESCRIPTION
# Overview 
There were three issues occurring in our build that were sometimes causing errors or warnings. This is to fix those things. 

## Issues Resolved

### partials/sidebar/index.js
Remember the Failed exporting HTML for URL gallery/area-hover-styles (/Users/brittanyfee nstra/repos/victory-docs/src/pages/gallery-item-template): Cannot read property 'filte r' of undefined error I mentioned in PR #658 (it's ok if not) - this is getting caused by filteredEdges coming back as undefined for the some URLs. By checking that filteredEdges exists before returning its categories the build issue resolves. I'm sure this is something that I refactored and accidentally removed - i was wondering why there were so many ternaries all over the sidenav, now I know why.

### static-config-helpers/md-data-transforms
linter was whining about arrow functions not explicitly returning, no more whining.

### static.config.js
Also back in PR #658 we decided to axe the generic 'guides' (victory-guides) page since it's redundant and you can't get to it unless you manually type it in or go straight from the home page link. What I did not know then and the ci pipeline did not catch is that you cannot simply delete the markdown and call it a day if that route still has children to attend to.
By updating the template of guides to the 404 it's no longer trying to get guide data that doesn't exist and it still allows the children to have the proper url path. the getData is updated to trueDocs so that the proper generic data on the 'docs' template is OK for the children (this is my loose understanding?) - I mostly have just come to the realization that this line is important for things to work and errors to not flash on the screen. Would love to learn more on this or be corrected.


## To Test
- pull and run code locally, see that everything still works
- do a build, see that it works
- click on a guide, see that the children render
- manually go to /guides and see the 404