### PR TITLE
WIP: Restructure page to put sidenav on top of footer

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -36,80 +36,83 @@ const GitHubIconContainer = styled.div`
 const About = ({ location, sidebarContent }) => {
   return (
     <Page sidebarContent={sidebarContent} location={location}>
-      <PageHeader>Victory: Charting for React and React Native</PageHeader>
-      <GitHubIconContainer>
-        {/*
-         * TODO: Customize these buttons
-         * https://github.com/FormidableLabs/formidable-landers/issues/175
-         */}
-        <iframe
-          src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=star&count=true&size=large"
-          frameBorder="0"
-          scrolling="0"
-          width="160px"
-          height="30px"
-        >
-          &nbsp;
-        </iframe>
-        <iframe
-          src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=watch&count=true&size=large&v=2"
-          frameBorder="0"
-          scrolling="0"
-          width="160px"
-          height="30px"
-        >
-          &nbsp;
-        </iframe>
-        <iframe
-          src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=fork&count=true&size=large"
-          frameBorder="0"
-          scrolling="0"
-          width="158px"
-          height="30px"
-        >
-          &nbsp;
-        </iframe>
-      </GitHubIconContainer>
-      <p>
-        Victory is a set of modular charting components for React and React
-        Native. Victory makes it easy to get started without sacrificing
-        flexibility. Create one of a kind data visualizations with fully
-        customizable styles and behaviors. Victory uses the same API for web and
-        React Native applications for easy cross-platform charting.
-      </p>
-      <p>
-        Victory is helmed by Formidable’s{" "}
-        <a href="https://github.com/boygirl"> Lauren Eastridge</a>.
-      </p>
-      <p>
-        <a href="https://github.com/FormidableLabs/victory/graphs/contributors">
-          See Victory Contributors
-        </a>
-      </p>
-
-      <Divider />
-
-      <Section>
-        <Subheader id="showcase">Victory in Use</Subheader>
+      <div>
+        {/* This div is key to consistent bottom margin for the page given how the document playground is structured + the fixed menus on larger screens. */}
+        <PageHeader>Victory: Charting for React and React Native</PageHeader>
+        <GitHubIconContainer>
+          {/*
+           * TODO: Customize these buttons
+           * https://github.com/FormidableLabs/formidable-landers/issues/175
+           */}
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=star&count=true&size=large"
+            frameBorder="0"
+            scrolling="0"
+            width="160px"
+            height="30px"
+          >
+            &nbsp;
+          </iframe>
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=watch&count=true&size=large&v=2"
+            frameBorder="0"
+            scrolling="0"
+            width="160px"
+            height="30px"
+          >
+            &nbsp;
+          </iframe>
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=victory&type=fork&count=true&size=large"
+            frameBorder="0"
+            scrolling="0"
+            width="158px"
+            height="30px"
+          >
+            &nbsp;
+          </iframe>
+        </GitHubIconContainer>
         <p>
-          Victory is used for charting across the web, from publicly-consumed
-          informational graphs to internal tracking and reporting.
+          Victory is a set of modular charting components for React and React
+          Native. Victory makes it easy to get started without sacrificing
+          flexibility. Create one of a kind data visualizations with fully
+          customizable styles and behaviors. Victory uses the same API for web
+          and React Native applications for easy cross-platform charting.
         </p>
-      </Section>
-
-      <Showcase />
-
-      <Section>
-        <Subheader>About Formidable</Subheader>
         <p>
-          Formidable is a Seattle-based consultancy and development shop,
-          focused on open-source, full-stack JavaScript using React.js and
-          Node.js, and the architecture of large-scale JavaScript applications.
-          We build products for some of the world’s biggest companies, while
-          helping their internal teams develop smart, thoughtful, and scalable
-          systems.
+          Victory is helmed by Formidable’s{" "}
+          <a href="https://github.com/boygirl"> Lauren Eastridge</a>.
         </p>
-      </Section>
+        <p>
+          <a href="https://github.com/FormidableLabs/victory/graphs/contributors">
+            See Victory Contributors
+          </a>
+        </p>
+
+        <Divider />
+
+        <Section>
+          <Subheader id="showcase">Victory in Use</Subheader>
+          <p>
+            Victory is used for charting across the web, from publicly-consumed
+            informational graphs to internal tracking and reporting.
+          </p>
+        </Section>
+
+        <Showcase />
+
+        <Section>
+          <Subheader>About Formidable</Subheader>
+          <p>
+            Formidable is a Seattle-based consultancy and development shop,
+            focused on open-source, full-stack JavaScript using React.js and
+            Node.js, and the architecture of large-scale JavaScript
+            applications. We build products for some of the world’s biggest
+            companies, while helping their internal teams develop smart,
+            thoughtful, and scalable systems.
+          </p>
+        </Section>
+      </div>
     </Page>
   );
 };

--- a/src/partials/footer.js
+++ b/src/partials/footer.js
@@ -9,6 +9,11 @@ const FooterContainer = styled.footer`
   color: ${({ theme }) => theme.color.white};
   display: flex;
   justify-content: center;
+  padding-left: 2.8rem;
+  @media ${({ theme }) => theme.mediaQuery.md} {
+    padding: 12.7rem 29rem 13.3rem 0;
+    padding-left: ${({ theme }) => theme.layout.sidebarWidth};
+  }
 `;
 
 const InnerContainer = styled.div`
@@ -16,15 +21,11 @@ const InnerContainer = styled.div`
   flex-direction: column;
   height: ${({ theme }) => theme.layout.footerHeight};
   justify-content: center;
-  padding: 0 ${({ theme }) => theme.spacing.md};
   width: 100%;
 
   @media ${({ theme }) => theme.mediaQuery.md} {
     flex-direction: row;
-    height: ${({ theme }) => theme.layout.md.footerHeight};
-    max-width: ${({ theme }) => theme.layout.footerMaxWidth};
-    padding-bottom: ${({ theme }) => theme.spacing.lg};
-    padding-top: ${({ theme }) => theme.spacing.lg};
+    height: auto;
   }
 `;
 
@@ -55,6 +56,7 @@ const Icon = styled(SVG)`
 
 const Blurb = styled.p`
   margin: 0;
+  font-size: 1.6rem;
 `;
 
 const FormidableLink = styled.a`

--- a/src/partials/page.js
+++ b/src/partials/page.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import _Header from "./header";
 import _Sidebar from "../partials/sidebar";
-import Footer from "./footer";
+import _Footer from "./footer";
 
 // sidebar logic is as follows:
 // if on large devices, sidebar is only shown if the `withSidebar` prop is
@@ -11,20 +11,8 @@ import Footer from "./footer";
 // if on small devices, sidebar is always hidden until toggled open, regardless
 // of the value of `withSidebar`
 
-// the PageContainer and Header components need to be nudged over to make space
-// for the sidebar only on large devices if `withSidebar` is `true`
-
 const PageContainer = styled.main`
-  position: relative;
-  margin-left: ${({ theme }) => theme.layout.stripesWidth};
-  margin-top: ${({ theme }) => theme.layout.headerHeight};
-
-  @media ${({ theme }) => theme.mediaQuery.md} {
-    margin-left: ${({ spaceForSidebar, theme }) =>
-      `calc(${theme.layout.stripesWidth} + ${
-        spaceForSidebar ? theme.layout.sidebarWidth : "0rem"
-      })`};
-  }
+  display: flex;
 `;
 
 const Header = styled(_Header)`
@@ -32,31 +20,27 @@ const Header = styled(_Header)`
   position: fixed;
   top: 0;
   width: ${({ theme }) => `calc(100% - ${theme.layout.stripesWidth})`};
-  z-index: 4;
+  width; 100%;
+  z-index: ${({ showSidebar }) => (showSidebar ? 4 : 7)};
 
   @media ${({ theme }) => theme.mediaQuery.md} {
     left: ${({ spaceForSidebar, theme }) =>
-      `calc(${theme.layout.stripesWidth} + ${
-        spaceForSidebar ? theme.layout.sidebarWidth : "0rem"
-      })`};
-    width: ${({ spaceForSidebar, theme }) =>
-      `calc(100% - ${theme.layout.stripesWidth} - ${
-        spaceForSidebar ? theme.layout.sidebarWidth : "0rem"
-      })`};
+      `calc(${spaceForSidebar ? theme.layout.sidebarWidth : "0rem"})`};
+    width: 100%;
   }
 `;
 
 const SidebarContainer = styled.aside`
   display: flex;
-  height: 100%;
-  position: fixed;
-  left: 0;
-  top: 0;
   z-index: 5;
+  height: 100vh;
+  @media ${({ theme }) => theme.mediaQuery.md} {
+    width: ${({ theme, showMd }) => (showMd ? theme.layout.sidebarWidth : 0)};
+  }
 `;
 
 const stripeStyle = css`
-  height: 100%;
+  height: 100vh;
   width: ${({ theme }) => `calc(${theme.layout.stripesWidth} / 2)`};
 `;
 
@@ -72,7 +56,6 @@ const PaleRedStripe = styled.div`
 
 const Sidebar = styled(_Sidebar)`
   display: ${({ show }) => (show ? "block" : "none")};
-
   @media ${({ theme }) => theme.mediaQuery.md} {
     display: ${({ showMd }) => (showMd ? "block" : "none")};
   }
@@ -80,19 +63,35 @@ const Sidebar = styled(_Sidebar)`
 
 const ContentContainer = styled.article`
   display: flex;
+  height: 100vh;
+  overflow: scroll;
   justify-content: center;
   padding: ${({ theme }) =>
     `${theme.layout.pageGutterTop} ${theme.layout.pageGutterRight} ${theme.layout.pageGutterBottom} ${theme.layout.pageGutterLeft}`};
+  width: 100vw;
+  position: absolute;
 
   @media ${({ theme }) => theme.mediaQuery.md} {
     padding: ${({ theme }) =>
       `${theme.layout.md.pageGutterTop} ${theme.layout.md.pageGutterRight} ${theme.layout.md.pageGutterBottom} ${theme.layout.md.pageGutterLeft}`};
+    position: inherit;
   }
 `;
 
 const Content = styled.div`
+  margin-top: ${({ theme }) => theme.layout.headerHeight};
   max-width: ${({ theme }) => theme.layout.maxWidth};
   width: 100%;
+  & > div:first-of-type {
+    margin-bottom: 6rem;
+    @media ${({ theme }) => theme.mediaQuery.md} {
+      margin-bottom: 12.1rem;
+    }
+  }
+`;
+
+const Footer = styled(_Footer)`
+  width: 100vw;
 `;
 
 const Page = props => {
@@ -119,31 +118,32 @@ const Page = props => {
   });
 
   return (
-    <PageContainer spaceForSidebar={withSidebar} className="Page-content">
+    <>
       <Header
         location={location}
+        showSidebar={sidebarOpen}
         spaceForSidebar={withSidebar}
         onMenuClick={() => setSidebarOpen(true)}
       />
+      <PageContainer spaceForSidebar={withSidebar} className="Page-content">
+        <SidebarContainer ref={ref} showMd={withSidebar}>
+          <RedStripe />
+          <PaleRedStripe />
+          <Sidebar
+            location={location}
+            show={sidebarOpen}
+            showMd={withSidebar}
+            content={sidebarContent}
+            onCloseClick={() => setSidebarOpen(false)}
+          />
+        </SidebarContainer>
 
-      <SidebarContainer ref={ref}>
-        <RedStripe />
-        <PaleRedStripe />
-        <Sidebar
-          location={location}
-          show={sidebarOpen}
-          showMd={withSidebar}
-          content={sidebarContent}
-          onCloseClick={() => setSidebarOpen(false)}
-        />
-      </SidebarContainer>
-
-      <ContentContainer>
-        <Content>{children}</Content>
-      </ContentContainer>
-
+        <ContentContainer showMd={withSidebar}>
+          <Content>{children}</Content>
+        </ContentContainer>
+      </PageContainer>
       <Footer />
-    </PageContainer>
+    </>
   );
 };
 

--- a/src/partials/sidebar/index.js
+++ b/src/partials/sidebar/index.js
@@ -49,7 +49,7 @@ const SidebarContainer = styled.nav`
   background-color: ${({ theme }) => theme.color.nearWhite};
   overflow: scroll;
   overflow-x: hidden;
-  padding: 1.8rem 0;
+  padding: 1.8rem 0 4rem;
   position: relative;
   width: ${({ theme }) => theme.layout.sidebarWidth};
 `;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -63,14 +63,14 @@ const theme = {
     stripesWidth: "2.8rem",
     sidebarWidth: "26rem",
 
-    pageGutterLeft: "2rem",
+    pageGutterLeft: "5.8rem", // account for stripesWidth
     pageGutterRight: "3rem",
     pageGutterTop: "2rem",
     pageGutterBottom: "5.5rem",
 
     // layout at md width and larger; use in conjunction with media query
     md: {
-      footerHeight: "25.6rem",
+      footerHeight: "36.5rem",
 
       pageGutterLeft: "6rem",
       pageGutterRight: "7.5rem",


### PR DESCRIPTION
# Overview 
The sidenav was previously overlapping with the footer but really we want the sidenav to end on top of the footer. Addressing this change forced some structural updates to keep the header and side nav fixed but allow the different scroll for sidenav vs article and footer. 

## Updates 
- Moving the header and footer outside of the `main` tag to separate html spaces. 
- This also allows more natural breakage for the fixed header + fixed sidebar with the docs to fill as much space as necessary and then scroll to the footer. 
- By making this move for the header/footer so that the `<main>` is just the nav and the articles we can more readily have the required fixed full `100vh` `<aside>` when on docs and hide it on other pages. I tried a few ways of doing this and to me this was the most legible for future updates and the least convoluted.

### Secondary updates to accommodate the switch to keep the sidenav above the footer
- While doing this I also adjusted the footer spacing and font size to match zeplin docs
- As well addressing the padding inconsistency between docs and gallery vs about pages 
- Footer height should be `365px` not `256px` according to [zeplin docs](https://app.zeplin.io/project/5de59860cf69e96dc05a5344/screen/5de6f49d90b42b48b98a68d1)
- left page gutter needs to account for stripes width on smaller view ports given the updates i made to allow the fixed scroll with footer below.


## Testing
- pull and run branch:
  - scroll through docs and see that in desktop the footer and aside do not overlap
  - on gallery and about see that the side nav does not show up on large viewports 
  - view mobile size viewport and see that the sidenav is a drawer for all three pages and still does not overlap with the footer (I kinda feel like this might be better to actually overlap on top of the footer in this case but opted for initial consistency) 


## Screen shots 
![sidebarstacked](https://user-images.githubusercontent.com/10720454/75489588-64734180-5967-11ea-9292-4e93670fd95f.gif)

![mobile scroll](https://user-images.githubusercontent.com/10720454/75489577-5e7d6080-5967-11ea-81d4-07951d85e951.gif)

