### PR TITLE
Rewrite todos

### DIFF
--- a/src/content/gallery/stacked-bars-central-axis.md
+++ b/src/content/gallery/stacked-bars-central-axis.md
@@ -21,8 +21,8 @@ const dataB = dataA.map((point) => {
   return { ...point, y };
 });
 
-const width = 500;
-const height = 300;
+const width = 400;
+const height = 400;
 
 class App extends React.Component {
 
@@ -31,9 +31,10 @@ class App extends React.Component {
       <VictoryChart horizontal
         height={height}
         width={width}
+        padding={40}
       >
         <VictoryStack
-          style={{ data: { width: 20 }, labels: { fontSize: 11 } }}
+          style={{ data: { width: 25 }, labels: { fontSize: 15 } }}
         >
           <VictoryBar
             style={{ data: { fill: "tomato" } }}
@@ -52,7 +53,7 @@ class App extends React.Component {
           style={{
             axis: { stroke: "transparent" },
             ticks: { stroke: "transparent" },
-            tickLabels: { fontSize: 11, fill: "black" }
+            tickLabels: { fontSize: 15, fill: "black" }
           }}
           /*
             Use a custom tickLabelComponent with

--- a/src/partials/footer.js
+++ b/src/partials/footer.js
@@ -57,31 +57,41 @@ const Blurb = styled.p`
   margin: 0;
 `;
 
-const FormidableLink = styled.a`
-  color: inherit;
-`;
-
 const Footer = ({ className = "" }) => (
   <FooterContainer className={className}>
     <InnerContainer>
       <IconAndContact>
-        <a href="https://formidable.com">
+        <a
+          href="https://formidable.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Icon src={formidableIcon} />
         </a>
         <Contact>
-          <a href="https://formidable.com/contact/">CONTACT</a>
-          <a href="https://formidable.com/careers/">CAREERS</a>
+          <a
+            href="https://formidable.com/contact/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            CONTACT
+          </a>
+          <a
+            href="https://formidable.com/careers/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            CAREERS
+          </a>
         </Contact>
       </IconAndContact>
       <Blurb>
-        Formidable is a Seattle, Denver, Phoenix, and London-based engineering
+        Formidable is a Seattle, Denver, Phoenix and London-based engineering
         consultancy and open source software organization, specializing in
         React.js, React Native, GraphQL, Node.js, and the extended JavaScript
-        ecosystem. For more information about Formidable, please visit{" "}
-        <FormidableLink href="https://formidable.com" target="_blank">
-          formidable.com
-        </FormidableLink>
-        .
+        ecosystem. We build products for some of the world’s biggest companies,
+        while helping their internal teams develop smart, thoughtful, and
+        scalable systems.
       </Blurb>
     </InnerContainer>
   </FooterContainer>

--- a/src/partials/header.js
+++ b/src/partials/header.js
@@ -106,6 +106,7 @@ const FormidableIcon = styled(SVG)`
 `;
 
 const FormidableLogo = styled(SVG)`
+  color: ${({ theme }) => theme.color.nearBlack};
   display: none;
   height: 2.8rem;
   position: relative;
@@ -156,7 +157,12 @@ const Header = ({ className = "", onMenuClick }) => {
             </NavLink>
 
             {config.projectLinks.map(link => (
-              <NavAnchor key={link.url} href={link.url}>
+              <NavAnchor
+                key={link.url}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {link.label}
               </NavAnchor>
             ))}
@@ -170,8 +176,20 @@ const Header = ({ className = "", onMenuClick }) => {
           </NavLinksList>
         </LeftContainer>
 
-        <FormidableIcon src={formidableIcon} />
-        <FormidableLogo src={formidableLogo} />
+        <a
+          href="https://formidable.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <FormidableIcon src={formidableIcon} />
+        </a>
+        <a
+          href="https://formidable.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <FormidableLogo src={formidableLogo} />
+        </a>
       </InnerContainer>
     </HeaderContainer>
   );

--- a/src/partials/home/_content.js
+++ b/src/partials/home/_content.js
@@ -27,11 +27,13 @@ const content = {
       },
       {
         text: "SUPPORT",
-        location: "https://spectrum.chat/victory"
+        location: "https://spectrum.chat/victory",
+        external: true
       },
       {
         text: "GITHUB",
-        location: "https://github.com/FormidableLabs/victory"
+        location: "https://github.com/FormidableLabs/victory",
+        external: true
       },
       {
         text: "FAQS",

--- a/src/partials/home/hero.js
+++ b/src/partials/home/hero.js
@@ -229,7 +229,13 @@ const Hero = ({
     <HeroContainer bg={background}>
       <Corner>
         <CornerText>{cornerText}</CornerText>
-        <CornerF src={cornerIcon} />
+        <a
+          href="https://formidable.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <CornerF src={cornerIcon} />
+        </a>
       </Corner>
       <LandingSectionContent>
         <CenterWrapper>

--- a/src/partials/home/hero.js
+++ b/src/partials/home/hero.js
@@ -251,11 +251,22 @@ const Hero = ({
           </GetStarted>
         </CenterWrapper>
         <LinkContainer>
-          {linksArray.map(l => (
-            <LinkItem key={l.text} href={createPath(l.location)}>
-              {l.text}
-            </LinkItem>
-          ))}
+          {linksArray.map(l => {
+            return l.external ? (
+              <LinkItem
+                key={l.text}
+                href={l.location}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {l.text}
+              </LinkItem>
+            ) : (
+              <LinkItem key={l.text} href={createPath(l.location)}>
+                {l.text}
+              </LinkItem>
+            );
+          })}
         </LinkContainer>
         <LearnMore to="Features" smooth offset={-25} duration={500}>
           LEARN MORE

--- a/src/partials/home/more-oss.js
+++ b/src/partials/home/more-oss.js
@@ -106,7 +106,7 @@ const MoreOSS = ({ ossArray, link }) => (
       <OSSWrapper>
         {ossArray.map((card, index) => (
           <OSSItem key={card.link} index={index}>
-            <OSSLink href={card.link}>
+            <OSSLink href={card.link} target="_blank" rel="noopener noreferrer">
               {card.featured ? (
                 <FeaturedBadge isHoverable name={card.title.toLowerCase()} />
               ) : (
@@ -119,7 +119,11 @@ const MoreOSS = ({ ossArray, link }) => (
               )}
             </OSSLink>
             <OSSCopyContainer>
-              <OSSLink href={card.link}>
+              <OSSLink
+                href={card.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <OSSTitle>{card.title}</OSSTitle>
               </OSSLink>
               <OSSText>{card.description}</OSSText>

--- a/src/partials/home/styles/link-button.js
+++ b/src/partials/home/styles/link-button.js
@@ -5,7 +5,11 @@ import { Link } from "react-router-dom";
 // * Use isExternal prop to create an anchor link with the same styling
 // eslint-disable-next-line no-unused-vars
 const LinkButton = styled(({ isExternal, noMargin, ...props }) =>
-  isExternal ? <a {...props} href={props.to} /> : <Link {...props} />
+  isExternal ? (
+    <a {...props} href={props.to} target="_blank" rel="noopener noreferrer" />
+  ) : (
+    <Link {...props} />
+  )
 )`
   background-color: ${({ bg, theme }) => bg || theme.color.white};
   color: ${({ color, theme }) => color || theme.color.black};

--- a/src/partials/sidebar/components/introduction.js
+++ b/src/partials/sidebar/components/introduction.js
@@ -24,7 +24,11 @@ const renderMobileSidebarLinks = mobileLinks => {
     return (
       <SidebarListItem key={link.slug}>
         {isExternal ? (
-          <SidebarListItemAnchorLink href={link.slug} target="_blank">
+          <SidebarListItemAnchorLink
+            href={link.slug}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             {link.title}
           </SidebarListItemAnchorLink>
         ) : (

--- a/src/partials/sidebar/components/table-of-contents.js
+++ b/src/partials/sidebar/components/table-of-contents.js
@@ -115,7 +115,7 @@ const TableOfContents = ({ active, link, headings }) => {
             return <li key={`${i}-${depth}`}>{getTOC(tocLink, item, i++)}</li>;
           }
 
-          return item.depth > 1 ? (
+          return item.depth === 2 ? (
             <SubItemListItem key={index} depth={item.depth}>
               <SubItemLink
                 depth={item.depth}

--- a/static.config.js
+++ b/static.config.js
@@ -116,8 +116,11 @@ export default {
         children: guides.map(g => ({
           path: `/${g.data.slug}`,
           template: g.component || "src/pages/docs-template",
-          getData: () => ({ doc: g, title: `Victory | ${g.name}` }),
-          sharedData: { sidebarContent: sharedSidebarContent }
+          getData: () => ({
+            doc: g,
+            title: `Victory | ${g.name}`,
+            sidebarContent: sbContent
+          })
         }))
       },
       {


### PR DESCRIPTION
This PR adds some polish for the new docs including
- auditing for external links and making sure they open in new tabs
- fixing an issue with cached shared data for guides routes
- not rendering deeply nested hierarchy in the sidebar
- tweaking styles for one of the gallery examples