### PR TITLE
sharedData not working for child routes

### DIFF
--- a/static.config.js
+++ b/static.config.js
@@ -134,8 +134,7 @@ export default {
         children: docSubroutes.map(doc => ({
           path: `/${doc.data.slug}`,
           template: "src/pages/docs-template",
-          getData: () => ({ doc }),
-          sharedData: { sidebarContent: sharedSidebarContent }
+          getData: () => ({ doc, sidebarContent: sbContent })
         }))
       },
       {


### PR DESCRIPTION
Don't use shared data for child routes. Isn't properly caching