### PR TITLE
Fix URL that is 404ing: /open-source/victory/guides

### DIFF
--- a/src/pages/redirect.js
+++ b/src/pages/redirect.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withRouteData } from "react-static";
+import { Redirect } from "react-router";
+import createPath from "../helpers/path-helpers";
+
+const RedirectPage = props => {
+  return <Redirect to={createPath(props.redirect)} />;
+};
+
+RedirectPage.propTypes = {
+  redirect: PropTypes.string.isRequired
+};
+
+export default withRouteData(RedirectPage);

--- a/static-config-helpers/site-data.js
+++ b/static-config-helpers/site-data.js
@@ -17,7 +17,7 @@ export default {
       url: "https://github.com/FormidableLabs/victory"
     }
   ],
-  copyright: "Copyright © 2019. Formidable", // Copyright string for the footer of the website and RSS feed.
+  copyright: `Copyright © ${new Date().getFullYear()} Formidable`, // Copyright string for the footer of the website and RSS feed.
   themeColor: "#c62828", // Used for setting manifest and progress theme colors.
   backgroundColor: "#e0e0e0" // Used for setting manifest background color.
 };

--- a/static.config.js
+++ b/static.config.js
@@ -109,9 +109,14 @@ export default {
         sharedData: { sidebarContent: sharedSidebarContent }
       },
       {
-        path: "/guides", // guides shares the 404 template because its children have their own docs-template getting used and there is no parent page to render, removing this will cause you build issues
-        template: "src/pages/404",
-        getData: () => ({ docs: trueDocs }),
+        // The "/guides" URL used to be a page, but is no longer. Because it is linked to from other documentation,
+        // do a redirect to the first guide.
+        path: "/guides",
+        template: "src/pages/redirect",
+        getData: () => {
+          const firstGuidePath = `/guides/${guides[0].data.slug}`;
+          return { redirect: firstGuidePath };
+        },
         sharedData: { sidebarContent: sharedSidebarContent },
         children: guides.map(g => ({
           path: `/${g.data.slug}`,


### PR DESCRIPTION
This PR makes the URL `https://formidable.com/open-source/victory/guides/` redirect to whatever the first guide is -- currently `https://formidable.com/open-source/victory/guides/animations`

The URL is linked to from `https://github.com/FormidableLabs/victory/blob/c862f151d60f872337dc3e7f676c16ee4085673f/README.md` and `https://github.com/FormidableLabs/victory/blob/c862f151d60f872337dc3e7f676c16ee4085673f/ISSUE_TEMPLATE.md` and potentially other places.