### PR TITLE
Speed up transition between same documentation page

### DIFF
--- a/src/pages/docs-template.js
+++ b/src/pages/docs-template.js
@@ -6,7 +6,7 @@ import config from "../../static-config-helpers/site-data";
 import Markdown from "../partials/markdown";
 import Page from "../partials/page";
 
-const DocsTemplate = ({ doc, sidebarContent }) => {
+const DocsTemplate = React.memo(({ doc, sidebarContent }) => {
   const { content, data } = doc;
   const { title, scope } = data;
   return (
@@ -20,7 +20,7 @@ const DocsTemplate = ({ doc, sidebarContent }) => {
       <Markdown source={content} scope={scope} />
     </Page>
   );
-};
+});
 
 DocsTemplate.propTypes = {
   children: PropTypes.array,


### PR DESCRIPTION
Right now when you navigate via the sidebar to different sections. So if you are on `VictoryBar` and navigate from prop to prop by clicking on the sidebar links, it takes a few seconds, and then jumps to that section. This is only an issue on pages that render charts, which is most of them. This fixes that issue by preventing the markdown component from re-rendering. So now transitioning from section to section now is immediate, and each section is smoothly scrolled to as intended.