### PR TITLE
Fix voronai container example link

### DIFF
--- a/src/content/docs/victory-voronoi-container.md
+++ b/src/content/docs/victory-voronoi-container.md
@@ -238,4 +238,4 @@ _example:_ `voronoiPadding={5}`
 
 [victorycontainer]: /docs/victory-container
 [voronoi diagram]: https://github.com/d3/d3-voronoi
-[this example]: /gallery/voronoi-tooltips-grouped
+[this example]: /gallery/voronoi-tooltips-with-grouped-components


### PR DESCRIPTION
**Issue**
The *this example* link in the [documentation for VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container) leads to a *404 Not found* page.

**Cause**
The link seems to refer to the name of the documentation page, while the actual URL is based on the name of the page.

**Fix**
This PR fixes the 404 Not found issue by change the link to point to the name of the example page.